### PR TITLE
remove redundant code from src/build

### DIFF
--- a/src/build/Commands/BuildCommand.cs
+++ b/src/build/Commands/BuildCommand.cs
@@ -7,7 +7,6 @@ using CommandLine;
 using CommandLine.Text;
 using ElastiBuild.BullseyeTargets;
 using ElastiBuild.Extensions;
-using ElastiBuild.Infra;
 using Elastic.Installer;
 
 namespace ElastiBuild.Commands
@@ -131,9 +130,7 @@ namespace ElastiBuild.Commands
 
             try
             {
-                await bt.RunWithoutExitingAsync(
-                    productBuildTargets,
-                    logPrefix: "ElastiBuild");
+                await bt.RunWithoutExitingAsync(productBuildTargets);
             }
             catch
             {

--- a/src/build/Commands/CleanCommand.cs
+++ b/src/build/Commands/CleanCommand.cs
@@ -54,9 +54,7 @@ namespace ElastiBuild.Commands
 
             try
             {
-                await bt.RunWithoutExitingAsync(
-                    "Clean".Split(),
-                    logPrefix: "ElastiBuild");
+                await bt.RunWithoutExitingAsync("Clean".Split());
             }
             catch
             {

--- a/src/build/Commands/FetchCommand.cs
+++ b/src/build/Commands/FetchCommand.cs
@@ -53,9 +53,7 @@ namespace ElastiBuild.Commands
 
             try
             {
-                await bt.RunWithoutExitingAsync(
-                    productBuildTargets,
-                    logPrefix: "ElastiBuild");
+                await bt.RunWithoutExitingAsync(productBuildTargets);
             }
             catch
             {

--- a/src/build/Program.cs
+++ b/src/build/Program.cs
@@ -3,21 +3,15 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommandLine;
 using CommandLine.Text;
-using Elastic.Installer;
 using ElastiBuild.Commands;
 using ElastiBuild.Infra;
 using ElastiBuild.Options;
 
 namespace ElastiBuild
 {
-    partial class Program
+    static class Program
     {
         static async Task Main(string[] args)
-        {
-            await new Program().Run(args);
-        }
-
-        async Task Run(string[] args)
         {
 #if DEBUG
             //args = "build --cid 8.0-snapshot functionbeat".Split();
@@ -44,7 +38,7 @@ namespace ElastiBuild
                 async (errs) => await HandleErrorsAndShowHelp(result, commands));
         }
 
-        Task HandleErrorsAndShowHelp(ParserResult<object> parserResult, Type[] commands)
+        static Task HandleErrorsAndShowHelp(ParserResult<object> parserResult, Type[] commands)
         {
             SentenceBuilder.Factory = () => new TweakedSentenceBuilder();
 


### PR DESCRIPTION
Note that the default log prefix is the name of the entry assembly, which is already "ElastiBuild".