### PR TITLE
Create a buildkite pipeline to replace Jenkins

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,7 @@
+steps:
+  - label: ":hammer: Build stack installers"
+    command: ".buildkite/scripts/build.ps1"
+    artifact_paths: "bin/out/*"
+    agents:
+      provider: gcp
+      image: family/ci-windows-2022

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -1,0 +1,3 @@
+& "./tools/dotnet-install.ps1" -NoPath -JSonFile global.json -Architecture "x64" -InstallDir c:/dotnet-sdk
+${env:PATH} = "c:\dotnet-sdk;" + ${env:PATH}
+./build show


### PR DESCRIPTION
This pipeline replaced the existing jenkins one defined here. 
It doesn't do much, but is equivalent to the one in Jenkins. 
The next step is to grab the script from the RM and add it here in a follow up PR and upload artefacts.

Rel https://github.com/elastic/release-eng/issues/529