### PR TITLE
Snapshot-bugfix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env: 
-  # BRANCH: "${BUILDKITE_BRANCH}"
+  BRANCH: ""
 
 steps:
   - group: ":beats: Stack installers Snapshot"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
-env: 
-  BRANCH: ""
+# env: 
+#   BRANCH: "main"
 
 steps:
   - group: ":beats: Stack installers Snapshot"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,6 @@ steps:
     key: "dra-snapshot"
     steps:
     - label: ":hammer: Build stack installers Snapshot"
-      if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_SNAPSHOT") == "true"
       command: ".buildkite/scripts/build.ps1"
       key: "build-snapshot"
       artifact_paths: "bin/out/**/*.msi"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,15 @@
-# env: 
-#   BRANCH: "main"
+###
+### The following environment variables can be set for testing purposes via the buildkite UI or CLI
+###  RUN_SNAPSHOT: "true" - will run the snapshot workflow
+###  RUN_STAGING: "true" - will run the staging workflow
+###  DBRANCH: "main" - will override the dra branch param. Default is $BUILDKITE_BRANCH
 
 steps:
   - group: ":beats: Stack installers Snapshot"
     key: "dra-snapshot"
     steps:
     - label: ":hammer: Build stack installers Snapshot"
-      if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
+      if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_SNAPSHOT") == "true"
       command: ".buildkite/scripts/build.ps1"
       key: "build-snapshot"
       artifact_paths: "bin/out/**/*.msi"
@@ -16,7 +19,7 @@ steps:
       env: 
         WORKFLOW: "snapshot"
     - label: ":package: DRA Publish Snapshot"
-      if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
+      if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_SNAPSHOT") == "true"
       command: ".buildkite/scripts/dra-publish.sh"
       key: "publish-snapshot"
       depends_on: "build-snapshot"
@@ -28,7 +31,7 @@ steps:
     key: "dra-staging"
     steps:
     - label: ":hammer: Build stack installers staging"
-      if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
+      if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_STAGING") == "true"
       command: ".buildkite/scripts/build.ps1"
       key: "build-staging"
       artifact_paths: "bin/out/**/*.msi"
@@ -38,7 +41,7 @@ steps:
       env: 
         WORKFLOW: "staging"
     - label: ":package: DRA Publish staging"
-      if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
+      if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_STAGING") == "true"
       command: ".buildkite/scripts/dra-publish.sh"
       key: "publish-staging"
       depends_on: "build-staging"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env: 
-  BRANCH: "${BUILDKITE_BRANCH}"
+  # BRANCH: "${BUILDKITE_BRANCH}"
 
 steps:
   - group: ":beats: Stack installers Snapshot"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@
 ###  RUN_SNAPSHOT: "true" - will run the snapshot workflow
 ###  RUN_STAGING: "true" - will run the staging workflow
 ###  DBRANCH: "main" - will override the dra branch param. Default is $BUILDKITE_BRANCH
+###
 
 steps:
   - group: ":beats: Stack installers Snapshot"

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -27,7 +27,7 @@ Remove-Item bin/in -Recurse -Force -ErrorAction Ignore
 New-Item bin/in -Type Directory -Force
 if ($workflow -eq "snapshot") {
     $version = $stack_version + "-" + $workflow.ToUpper()
-    $hostname = "artifacts-snapshots.elastic.co"
+    $hostname = "artifacts-snapshot.elastic.co"
     $response = Invoke-WebRequest -UseBasicParsing -Uri "https://$hostname/beats/latest/$version.json"
     $json = $response.Content | ConvertFrom-Json
     $buildId = $json.build_id

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -27,11 +27,11 @@ Remove-Item bin/in -Recurse -Force -ErrorAction Ignore
 New-Item bin/in -Type Directory -Force
 if ($workflow -eq "snapshot") {
     $version = $stack_version + "-" + $workflow.ToUpper()
-    $response = Invoke-WebRequest -UseBasicParsing -Uri "https://artifacts-api.elastic.co/v1/versions/$version/builds/latest"
+    $hostname = "artifacts-snapshots.elastic.co"
+    $response = Invoke-WebRequest -UseBasicParsing -Uri "https://$hostname/beats/latest/$version.json"
     $json = $response.Content | ConvertFrom-Json
-    $buildId = $json.build.build_id
-    $hostname = "snapshots.elastic.co"
-    $prefix = "$hostname/$buildId"
+    $buildId = $json.build_id
+    $prefix = "$hostname/beats/$buildId"
 } else {
     $version = $stack_version
     $hostname = "artifacts-staging.elastic.co"

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -23,7 +23,7 @@ export VERSION
 if [ "$WORKFLOW" == "staging" ]; then
     MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
 else
-    MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION"-"$WORKFLOW".json | jq -r '.manifest_url')
+    MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION"-SNAPSHOT.json | jq -r '.manifest_url')
 fi
 
 if [ -n "$DBRANCH" ]; then

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -23,9 +23,9 @@ VERSION=$(cat Directory.Build.props | awk -F'[><]' '/<StackVersion>/{print $3}' 
 export VERSION
 
 if [ "$WORKFLOW" == "staging" ]; then
-    MANIFEST_URL=$(curl https://artifacts-staging.elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
+    MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
 else
-    MANIFEST_URL=$(curl https://artifacts-api.elastic.co/v1/versions/"$VERSION"-SNAPSHOT/builds/latest/projects/beats | jq -r '.project.external_artifacts_manifest_url')
+    MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
 fi
 # Publish DRA artifacts
 function run_release_manager() {

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -60,5 +60,3 @@ run_release_manager
 RM_EXIT_CODE=$?
 
 exit $RM_EXIT_CODE
-# stacking manifest https://artifacts-staging.elastic.co/beats/latest/8.6.3.json manifest_url
-# snapshot manifest https://artifacts-api.elastic.co/v1/versions/8.6.3-SNAPSHOT/builds/latest/projects/beats external_artifacts_manifest_url

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -uox pipefail
+set -uo pipefail
 
 
 # Download artifacts from Buildkite "Build stack installers" step
@@ -10,12 +10,11 @@ chmod -R 777 bin/out
 
 echo "+++ Setting DRA params" 
 # Shared secret path containing the dra creds for project teams
-set +x
 DRA_CREDS=$(vault kv get -field=data -format=json kv/ci-shared/release/dra-role)
 VAULT_ADDR=$(echo $DRA_CREDS | jq -r '.vault_addr')
 VAULT_ROLE_ID=$(echo $DRA_CREDS | jq -r '.role_id')
 VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id') 
-set -x
+BRANCH="${BUILDKITE_BRANCH}"
 export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 # Retrieve version value
 VERSION=$(cat Directory.Build.props | awk -F'[><]' '/<StackVersion>/{print $3}' | tr -d '[:space:]')
@@ -26,6 +25,11 @@ if [ "$WORKFLOW" == "staging" ]; then
 else
     MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION"-"$WORKFLOW".json | jq -r '.manifest_url')
 fi
+
+if [ -n "$DBRANCH" ]; then
+export BRANCH="$DBRANCH"
+fi
+
 # Publish DRA artifacts
 function run_release_manager() {
     echo "+++ Publishing $BUILDKITE_BRANCH ${WORKFLOW} DRA artifacts..."
@@ -33,7 +37,6 @@ function run_release_manager() {
     if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
         dry_run="--dry-run"
     fi
-    set +x # Disbable command tracing
     docker run --rm \
         --name release-manager \
         -e VAULT_ADDR="${VAULT_ADDR}" \
@@ -51,10 +54,11 @@ function run_release_manager() {
         --dependency beats:"${MANIFEST_URL}" \
         $dry_run \
         #
-    set -x # Disable command tracing
 }
 
 run_release_manager
+RM_EXIT_CODE=$?
 
+exit $RM_EXIT_CODE
 # stacking manifest https://artifacts-staging.elastic.co/beats/latest/8.6.3.json manifest_url
 # snapshot manifest https://artifacts-api.elastic.co/v1/versions/8.6.3-SNAPSHOT/builds/latest/projects/beats external_artifacts_manifest_url

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -20,15 +20,12 @@ export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 VERSION=$(cat Directory.Build.props | awk -F'[><]' '/<StackVersion>/{print $3}' | tr -d '[:space:]')
 export VERSION
 
-set -x
 if [ "$WORKFLOW" == "staging" ]; then
     MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
 else
     MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION"-SNAPSHOT.json | jq -r '.manifest_url')
 fi
-EXPORT MANIFEST_URL
-echo "$MANIFEST_URL"
-set +x
+
 if [ -n "$DBRANCH" ]; then
 export BRANCH="$DBRANCH"
 fi

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -20,12 +20,15 @@ export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 VERSION=$(cat Directory.Build.props | awk -F'[><]' '/<StackVersion>/{print $3}' | tr -d '[:space:]')
 export VERSION
 
+set -x
 if [ "$WORKFLOW" == "staging" ]; then
     MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
 else
     MANIFEST_URL=$(curl https://artifacts-"$WORKFLOW".elastic.co/beats/latest/"$VERSION"-SNAPSHOT.json | jq -r '.manifest_url')
 fi
-
+EXPORT MANIFEST_URL
+echo "$MANIFEST_URL"
+set +x
 if [ -n "$DBRANCH" ]; then
 export BRANCH="$DBRANCH"
 fi


### PR DESCRIPTION
Resolves 8.9 snapshot break

8.9 dra produce 
![image](https://user-images.githubusercontent.com/16253938/235485142-d3139bfa-becb-4564-b0c2-5d5b35f36a11.png)
The last invocation should resolve the beat dependency manifest https://buildkite.com/elastic/elastic-stack-installers/builds/304
After Merge needs to be backported to `8.8` & `8.7`