### PR TITLE
bump to 8.8.2

### DIFF
--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -1,4 +1,4 @@
-$stack_version="8.8.1"
+$stack_version="8.8.2"
 
 echo "~~~ Installing dotnet-sdk"
 & "./tools/dotnet-install.ps1" -NoPath -JSonFile global.json -Architecture "x64" -InstallDir c:/dotnet-sdk

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!--Elastic Stack version for this release -->
     <PropertyGroup>
-        <StackVersion>8.8.1</StackVersion>
+        <StackVersion>8.8.2</StackVersion>
     </PropertyGroup>
     
     <PropertyGroup>


### PR DESCRIPTION
Relates to [#715](https://github.com/elastic/release-eng/issues/715)

Bump stack installers version to 8.8.2