### PR TITLE
branch value for schedule must be string

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -63,7 +63,7 @@ spec:
           cronline: '@daily'
           message: Builds daily `main` stack-installers dra
         Weekly main:
-          branch: 7.17
+          branch: '7.17'
           cronline: '@weekly'
           message: Builds weekly  `7.17` stack-installers dra
       teams:


### PR DESCRIPTION
The branch value for a scheduled pipeline must be a string.

```
:no_entry:  Validation result:
:no_entry:	7.17 is not of type 'string'
:no_entry:
:no_entry:	Failed validating 'type' in schema['properties']['spec']['properties']['schedules']['patternProperties']['.*']['properties']['branch']:
:no_entry:	    {'type': 'string'}
:no_entry:
:no_entry:	On instance['spec']['schedules']['Weekly main']['branch']:
:no_entry:	    7.17
```
