### PR TITLE
Add a new pipeline to trigger a build if newer beats is available

### DIFF
--- a/.buildkite/scripts/check_beats.sh
+++ b/.buildkite/scripts/check_beats.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "steps:"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -74,3 +74,53 @@ spec:
         everyone:
           access_level: BUILD_AND_READ
         release-eng: {}
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-stack-installers-trigger
+  description: Buildkite Pipeline for elastic-stack-installers triggering
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-stack-installers-trigger
+spec:
+  type: buildkite-pipeline
+  owner: group:release-eng
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Elastic Stack Installer DRA Pipeline Trigger
+      name: elastic-stack-installers-trigger
+    spec:
+      pipeline_file: ".buildkite/scripts/check_beats.sh"
+      provider_settings:
+        build_branches: false
+        build_pull_request_forks: false
+        build_pull_requests: false
+        publish_commit_status: false
+        publish_commit_status_per_step: false
+      repository: elastic/elastic-stack-installers
+      schedules:
+        Daily 8_9:
+          branch: '8.9'
+          cronline: '*/10 * * * *'
+          message: Checking for new beats artefacts for `8.9`
+        Daily 8_8:
+          branch: '8.8'
+          cronline: '*/10 * * * *'
+          message: Checking for new beats artefacts for `8.8`
+        Daily main:
+          branch: main
+          cronline: '*/10 * * * *'
+          message: Checking for new beats artefacts for `main`
+        Weekly main:
+          branch: '7.17'
+          cronline: '*/10 * * * *'
+          message: Checking for new beats artefacts for `7.17`
+      teams:
+        everyone:
+          access_level: BUILD_AND_READ
+        release-eng: {}


### PR DESCRIPTION
This PR is the first part, to add an empty pipeline that can then be used to check for beats and trigger if newer is available.
