### PR TITLE
Remove 8.8 dra builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,10 +58,6 @@ spec:
           branch: '8.9'
           cronline: '@daily'
           message: Builds daily `8.9` stack-installers dra
-        Daily 8_8:
-          branch: '8.8'
-          cronline: '@daily'
-          message: Builds daily `8.8` stack-installers dra
         Daily main:
           branch: main
           cronline: '@daily'
@@ -108,10 +104,6 @@ spec:
           branch: '8.9'
           cronline: '*/10 * * * *'
           message: Checking for new beats artefacts for `8.9`
-        Daily 8_8:
-          branch: '8.8'
-          cronline: '*/10 * * * *'
-          message: Checking for new beats artefacts for `8.8`
         Weekly main:
           branch: '7.17'
           cronline: '*/10 * * * *'


### PR DESCRIPTION
Remove 8.8 DRA builds as 8.9 is released on 25-07-2023
Relates to[ #589](https://elasticco.atlassian.net/browse/REL-589)
https://github.com/elastic/release-eng/issues/733