### PR TITLE
Bump main to 8.11 add 8.10 to schedule

### DIFF
--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -1,4 +1,4 @@
-$stack_version="8.10.0"
+$stack_version="8.11.0"
 
 echo "~~~ Installing dotnet-sdk"
 & "./tools/dotnet-install.ps1" -NoPath -JSonFile global.json -Architecture "x64" -InstallDir c:/dotnet-sdk

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -54,18 +54,10 @@ spec:
         publish_commit_status_per_step: false
       repository: elastic/elastic-stack-installers
       schedules:
-        Daily 8_9:
-          branch: '8.9'
-          cronline: '@daily'
-          message: Builds daily `8.9` stack-installers dra
         Daily main:
           branch: main
           cronline: '@daily'
           message: Builds daily `main` stack-installers dra
-        Weekly main:
-          branch: '7.17'
-          cronline: '@weekly'
-          message: Builds weekly  `7.17` stack-installers dra
       teams:
         everyone:
           access_level: BUILD_AND_READ
@@ -100,6 +92,10 @@ spec:
         publish_commit_status_per_step: false
       repository: elastic/elastic-stack-installers
       schedules:
+        Daily 8_10:
+          branch: '8.10'
+          cronline: '*/10 * * * *'
+          message: Checking for new beats artefacts for `8.10`
         Daily 8_9:
           branch: '8.9'
           cronline: '*/10 * * * *'


### PR DESCRIPTION
Removes the direct triggers for non main builds, adds the beats trigger check for 8.10 and bumps main to 8.11
