### PR TITLE
Transfer repo and pipeline ownership to ingest-fp

### DIFF
--- a/.github/CODEONWERS
+++ b/.github/CODEONWERS
@@ -1,2 +1,0 @@
-# All
-* @elastic/release-eng

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @elastic/release-eng
+*   @elastic/ingest-fp

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     backstage.io/source-location: url:https://github.com/elastic/elastic-stack-installers/
     github.com/project-slug: elastic/elastic-stack-installers
-    github.com/team-slug: elastic/release-eng
+    github.com/team-slug: elastic/ingest-fp
 
   tags:
     - buildkite

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: elastic-stack-installers
-  description: Windows MSI packages for Elastic stack 
+  description: Windows MSI packages for Elastic stack
 
   annotations:
     backstage.io/source-location: url:https://github.com/elastic/elastic-stack-installers/
@@ -19,7 +19,7 @@ metadata:
 
 spec:
   type: tool
-  owner: group:release-eng
+  owner: group:ingest-fp
   lifecycle: beta
   dependsOn:
     - resource:github-repository-elastic-stack-installers
@@ -36,7 +36,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:release-eng
+  owner: group:ingest-fp
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -56,11 +56,12 @@ spec:
       schedules:
         Daily main:
           branch: main
-          cronline: '@daily'
+          cronline: "@daily"
           message: Builds daily `main` stack-installers dra
       teams:
         everyone:
           access_level: BUILD_AND_READ
+        ingest-fp: {}
         release-eng: {}
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
@@ -74,7 +75,7 @@ metadata:
       url: https://buildkite.com/elastic/elastic-stack-installers-trigger
 spec:
   type: buildkite-pipeline
-  owner: group:release-eng
+  owner: group:ingest-fp
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -93,14 +94,15 @@ spec:
       repository: elastic/elastic-stack-installers
       schedules:
         Daily 8_10:
-          branch: '8.10'
-          cronline: '*/10 * * * *'
+          branch: "8.10"
+          cronline: "*/10 * * * *"
           message: Checking for new beats artefacts for `8.10`
         Weekly main:
-          branch: '7.17'
-          cronline: '*/10 * * * *'
+          branch: "7.17"
+          cronline: "*/10 * * * *"
           message: Checking for new beats artefacts for `7.17`
       teams:
         everyone:
           access_level: BUILD_AND_READ
+        ingest-fp: {}
         release-eng: {}


### PR DESCRIPTION
This PR transfer the repository ownership from release-eng team to
the ingest-fp team.

The release-eng team will keep admin permissions for a while to finalize
the transfer and move the artifacts signing process outside of the
snapshot/staging pipeline.

cc @pazone  @roaksoax @pierrehilbert @alsayasneh 