### PR TITLE
Notify Ingest team when pipeline fails

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,5 +51,5 @@ steps:
           WORKFLOW: "staging"
 
 notify:
-  - slack: "#release-eng-alerts"
+  - slack: "#ingest-notifications"
     if: build.branch == 'main'


### PR DESCRIPTION
This PR update the Buildkite pipeline notifs to ping Ingest team Slack channel instead of Release Eng.