### PR TITLE
Don't make a signing certificate available

### DIFF
--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -5,17 +5,6 @@ echo "~~~ Installing dotnet-sdk"
 ${env:PATH} = "c:\dotnet-sdk;" + ${env:PATH}
 Get-Command dotnet | Select-Object -ExpandProperty Definition
 
-echo "~~~ Reading msi certificate from vault"
-$MsiCertificate=& vault read -field=cert secret/ci/elastic-elastic-stack-installers/msi
-$MsiPassword=& vault read -field=password secret/ci/elastic-elastic-stack-installers/msi
-Remove-Item Env:VAULT_TOKEN
-
-$cert_home="C:/.cert"
-New-Item $cert_home -Type Directory -Force
-[IO.File]::WriteAllBytes("$cert_home/msi_certificate.p12", [Convert]::FromBase64String($MsiCertificate))
-[IO.File]::WriteAllText("$cert_home/msi_password.txt", $MsiPassword)
-echo "Certificate successfully written to $cert_home"
-
 $client = new-object System.Net.WebClient
 $currentDir = $(Get-Location).Path
 $beats = @('auditbeat', 'filebeat', 'heartbeat', 'metricbeat', 'packetbeat', 'winlogbeat')
@@ -70,11 +59,7 @@ $args = @(
     "--",
     "build",
     "--cid",
-    $version,
-    "--cert-file",
-    "$cert_home/msi_certificate.p12",
-    "--cert-pass",
-    "$cert_home/msi_password.txt"
+    $version
 )
 $args += ($beats + $ossBeats)
 &dotnet $args

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ _ReSharper*/
 
 # Jetbrains cache
 src/.idea/
+.idea
 
 # Test cmd files
 src/*.cmd
+
+


### PR DESCRIPTION
This PR removes fetching the signing cert from vault. This should make this build run without signing without additional changes.
