### PR TITLE
Fix artifacts path for dra publish

### DIFF
--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -5,7 +5,10 @@ set -uo pipefail
 
 # Download artifacts from Buildkite "Build stack installers" step
 echo "+++ Downloading artifacts..."
-buildkite-agent artifact download 'bin\out\**\*.msi' . --step build-"${DRA_WORKFLOW}"
+# it's possible to also use unix style paths for download (users/buildkites/...)
+# but it's an experimental feature that needs an agent flag set: https://buildkite.com/docs/agent/v3#experimental-features-normalised-upload-paths
+buildkite-agent artifact download 'users\buildkite\esi\bin\out\**\*.msi' . --step build-"${DRA_WORKFLOW}"
+mv users/buildkite/esi/bin bin
 chmod -R 777 bin/out
 
 echo "+++ Setting DRA params" 


### PR DESCRIPTION
This commit fixes the downloaded artifacts path to the expected path by the release manager image (`bin/out`).

The original path was changed in #212 and the previous step because path lengths exceeded a limit imposed by the msi builder.

Example failure: https://buildkite.com/elastic/elastic-stack-installers/builds/3653#018d5d99-9403-41b5-9023-613016deb033/51-54