### PR TITLE
Do not use program data in Beats MSI installers

### DIFF
--- a/docs/beats.md
+++ b/docs/beats.md
@@ -13,7 +13,6 @@ Beats is the platform for single-purpose data shippers. They send data from hund
 
 ### Notes:
 
-- Configuration files (.yml), Kibana dashboards, security and monitoring modules, etc are installed into `%ProgramData%\Elastic\Beats\{beat name}` directory.
 - Beats that support running as Windows Service are registered as such. Service will **not** be started after installation finishes, because configuration file likely lacks proper host information for elasticsearch. In this version, user needs to manually edit the configuration file to point Beats to an elasticsearch cluster.
 - When running as a Windows Service, Beats will create their `logs` and `data` directories in the location mentioned above.
 

--- a/docs/elastibuild.md
+++ b/docs/elastibuild.md
@@ -4,7 +4,6 @@
 - Discover branches, versions and aliases
 - Fetch any beat from above
 - Build any beat from downloaded archives in non-OSS variant
-- Configuration and misc files installed into ProgramData/Elastic/{version}/Beats/{beat}/
 
 ### Get help:
 ```

--- a/src/installer/BeatPackageCompiler/Properties/Resources.Designer.cs
+++ b/src/installer/BeatPackageCompiler/Properties/Resources.Designer.cs
@@ -69,7 +69,7 @@ namespace BeatPackageCompiler.Properties {
         ///)
         ///
         ///set beat_bin=%~dp0%~n0
-        ///set beat_data=%ProgramData%\Elastic\Beats\%~n0
+        ///set beat_data=%beat_bin%
         ///
         ///&quot;%beat_bin%\%~n0.exe&quot; ^
         ///    --path.home &quot;%beat_bin%&quot; ^

--- a/src/installer/BeatPackageCompiler/Properties/Resources.resx
+++ b/src/installer/BeatPackageCompiler/Properties/Resources.resx
@@ -126,7 +126,7 @@ if "%args%" == "" (
 )
 
 set beat_bin=%~dp0%~n0
-set beat_data=%ProgramData%\Elastic\Beats\%~n0
+set beat_data=%beat_bin%
 
 "%beat_bin%\%~n0.exe" ^
     --path.home "%beat_bin%" ^


### PR DESCRIPTION
Store configuration, runtime, and log data in ProgramFiles.