### PR TITLE
Selectively skip and fix tests after PR#212

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,5 @@
 ###
 ### The following environment variables can be set for testing purposes via the buildkite UI or CLI
-###  RUN_SNAPSHOT: "true" - will run the snapshot workflow
-###  RUN_STAGING: "true" - will run the staging workflow
 ###  ONLY_AGENT: "true" - will build only the elastic-agent msi artifact
 ###
 
@@ -19,7 +17,10 @@ steps:
         env:
           DRA_WORKFLOW: "snapshot"
       - label: ":package: DRA Publish Snapshot"
-        if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_SNAPSHOT") == "true"
+        if: |
+          // Only run when triggered from Unified Release or via PRs. Note that PRs run it in dry-run mode (see dra-publish.sh)
+          build.env("BUILDKITE_PULL_REQUEST") != "false" ||
+            ( (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-snapshot"
         depends_on: "build-snapshot"
@@ -31,7 +32,10 @@ steps:
     key: "dra-staging"
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
-        if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_STAGING") == "true"
+        if: |
+          // Only run when triggered from Unified Release or via PRs targetting non-main, since there is no valid MANIFEST_URL for staging/main branch.
+          ( build.env("BUILDKITE_PULL_REQUEST") != "false" && build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ /^[0-9]+\.[0-9]+\$/ ) ||
+            ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
         command: ".buildkite/scripts/build.ps1"
         key: "build-staging"
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
@@ -41,7 +45,11 @@ steps:
         env:
           DRA_WORKFLOW: "staging"
       - label: ":package: DRA Publish staging"
-        if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_STAGING") == "true"
+        if: |
+          // Only run when triggered from Unified Release or via PRs targetting non-main, since there is no valid MANIFEST_URL for staging/main branch.
+          // Note that PRs run it in dry-run mode (see dra-publish.sh)
+          ( build.env("BUILDKITE_PULL_REQUEST") != "false" && build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ /^[0-9]+\.[0-9]+\$/ ) ||
+            ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-staging"
         depends_on: "build-staging"
@@ -49,7 +57,3 @@ steps:
           provider: gcp
         env:
           DRA_WORKFLOW: "staging"
-
-notify:
-  - slack: "#ingest-notifications"
-    if: build.branch == 'main'

--- a/.buildkite/scripts/test.ps1
+++ b/.buildkite/scripts/test.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 Set-Strictmode -version 3
 
-Write-Host "--- Running Tests"
+Write-Host "~~~ Running Tests"
 write-host (ConvertTo-Json $PSVersiontable -Compress)
 write-host "Running as: $([Environment]::UserName)"
 

--- a/.buildkite/scripts/test.ps1
+++ b/.buildkite/scripts/test.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = "Stop"
 Set-Strictmode -version 3
 
+Write-Host "--- Running Tests"
 write-host (ConvertTo-Json $PSVersiontable -Compress)
 write-host "Running as: $([Environment]::UserName)"
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,6 +58,11 @@ spec:
           access_level: BUILD_AND_READ
         ingest-fp: {}
         release-eng: {}
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -224,19 +224,24 @@ Function Has-AgentStandaloneLog {
 }
 
 Function Has-AgentFleetEnrollmentAttempt {
-    try {
+    if (-not (Has-AgentLogged)) { return $false }
+
+    foreach ($i in 0..5) {
         $LogFile = Get-AgentLogFile -Latest $True
-    }
-    catch {
-        return $false
+
+        $Content = Get-Content -raw $LogFile
+
+        if ($Content -like "*failed to perform delayed enrollment: fail to enroll: fail to execute request to fleet-server: lookup placeholder: no such host*") {
+            return $True
+        }
+
+        write-host "Waiting for agent to log fleet message"
+        start-sleep -seconds 3
     }
 
-    $Content = Get-Content -raw $LogFile
-
-    if ($Content -like "*failed to perform delayed enrollment: fail to enroll: fail to execute request to fleet-server: lookup placeholder: no such host*") {
-        return $True
-    }
-
+    write-host "Agent did not log fleet message"
+    write-host "Agent Logged to $LogFile :"
+    write-host $Content
     return $false
 }
 

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -458,7 +458,17 @@ Function Uninstall-MSI {
         throw "Uninstall-msi called without path to an MSI or a GUID"
     }
 
-    $msiArgs = @("""$Path""",$Guid).Where{$_} + $Interactive + $Flags
+    $msiargs = @()
+    if (-not [string]::IsNullOrWhiteSpace($Path)) {
+        $msiargs += @("""$Path""")
+    }
+    
+    if (-not [string]::IsNullOrWhiteSpace($Guid)) {
+        $msiargs += @($Guid)
+    }
+
+    $msiArgs += $Interactive
+    $msiArgs += $Flags
     
     $OpenFiles = @(Find-OpenFile | Where-Object {$_.Name -like "*Elastic\Agent*" -or $_.Name -like "*Elastic\Beats*"})
     foreach ($OpenFile in $OpenFiles) {

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -220,6 +220,9 @@ Function Has-AgentStandaloneLog {
         start-sleep -seconds 3
     }
 
+    write-host "Agent did not log standalone message"
+    write-host "Agent Logged:"
+    write-host $Content
     return $false
 }
 
@@ -386,7 +389,7 @@ Function Invoke-MSIExec {
 
     if ($LogToDir) {
         $LoggingDestination = (New-MSIVerboseLoggingDestination -Destination $LogToDir -Suffix $Action)
-        $arglist += " /l*v " + $LoggingDestination
+        $arglist += " /l*v " + """" + $LoggingDestination + """"
     }
 
     write-verbose "Invoking msiexec.exe $arglist"
@@ -436,7 +439,7 @@ Function Install-MSI {
         $LogToDir
     )
 
-    $msiArgs = @(@($Path) + $Interactive + $Flags)
+    $msiArgs = @(@("""$Path""") + $Interactive + $Flags)
 
     Invoke-MSIExec -Action i -Arguments $msiArgs -LogToDir $LogToDir
 }
@@ -455,7 +458,7 @@ Function Uninstall-MSI {
         throw "Uninstall-msi called without path to an MSI or a GUID"
     }
 
-    $msiArgs = @($Path,$Guid).Where{$_} + $Interactive + $Flags
+    $msiArgs = @("""$Path""",$Guid).Where{$_} + $Interactive + $Flags
     
     $OpenFiles = @(Find-OpenFile | Where-Object {$_.Name -like "*Elastic\Agent*" -or $_.Name -like "*Elastic\Beats*"})
     foreach ($OpenFile in $OpenFiles) {

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -160,13 +160,19 @@ Function Has-AgentInstallerProcess {
 }
 
 Function Has-AgentLogged {
-    try {
-        $LogFile = Get-AgentLogFile -Latest $True
-        return $true
+
+    foreach ($i in 0..5) {
+
+        try {
+            $LogFile = Get-AgentLogFile -Latest $True
+            return $true
+        } catch {}
+        
+        write-host "Waiting for agent to log message"
+        start-sleep -seconds 3
     }
-    catch {
-        return $false
-    }
+    
+    return $false
 }
 
 Function Is-AgentLogGrowing {
@@ -205,8 +211,13 @@ Function Has-AgentStandaloneLog {
 
     $Content = Get-Content -raw $LogFile
 
-    if ($Content -like "*Parsed configuration and determined agent is managed locally*") {
-        return $True
+    foreach ($i in 0..5) {
+        if ($Content -like "*Parsed configuration and determined agent is managed locally*") {
+            return $True
+        }
+
+        write-host "Waiting for agent to log standalone message"
+        start-sleep -seconds 3
     }
 
     return $false

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -202,16 +202,13 @@ Function Is-AgentLogGrowing {
 }
 
 Function Has-AgentStandaloneLog {
-    try {
-        $LogFile = Get-AgentLogFile -Latest $True
-    }
-    catch {
-        return $false
-    }
-
-    $Content = Get-Content -raw $LogFile
+    if (-not (Has-AgentLogged)) { return $false }
 
     foreach ($i in 0..5) {
+        $LogFile = Get-AgentLogFile -Latest $True
+
+        $Content = Get-Content -raw $LogFile
+
         if ($Content -like "*Parsed configuration and determined agent is managed locally*") {
             return $True
         }
@@ -221,7 +218,7 @@ Function Has-AgentStandaloneLog {
     }
 
     write-host "Agent did not log standalone message"
-    write-host "Agent Logged:"
+    write-host "Agent Logged to $LogFile :"
     write-host $Content
     return $false
 }
@@ -359,7 +356,7 @@ Function Clean-ElasticAgentDirectory {
 Function Clean-ElasticAgentUninstallKeys {
     $Keys = Get-AgentUninstallRegistryKey -Passthru
     if ($Keys) {
-        Remove-Item -Path $Keys
+        $Keys | Remove-Item -force -verbose
     }
 }
 


### PR DESCRIPTION
PR #212 made some changes on `main` that require the presence of `MANIFEST_URL`. However, the pipeline is still configured to run the same script when a PR (from an upstream branch) is raised and it currently fails.

This commit skips tests when triggered from another pipeline (unified release), and allows running tests when triggered by PR creation by picking up a suitable `MANIFEST_URL`.