### PR TITLE
Use BK PR bot via dedicated pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,9 @@
 steps:
   - group: ":package: Stack installers Snapshot"
     key: "dra-snapshot"
+    if: |
+      // Only run when triggered from Unified Release
+      ( (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" )
     steps:
       - label: ":construction_worker: Build stack installers / Snapshot"
         command: ".buildkite/scripts/build.ps1"
@@ -17,9 +20,6 @@ steps:
         env:
           DRA_WORKFLOW: "snapshot"
       - label: ":package: DRA Publish Snapshot"
-        if: |
-          // Only run when triggered from Unified Release
-          ( (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-snapshot"
         depends_on: "build-snapshot"
@@ -29,12 +29,11 @@ steps:
           DRA_WORKFLOW: "snapshot"
   - group: ":package: Stack installers Staging"
     key: "dra-staging"
+    if: |
+      // Only run when triggered from Unified Release
+      ( (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
-        if: |
-          // Only run when triggered from Unified Release or via PRs targetting non-main, since there is no valid MANIFEST_URL for staging/main branch.
-          ( build.env("BUILDKITE_PULL_REQUEST") != "false" && build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ /^[0-9]+\.[0-9]+\$/ ) ||
-            ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
         command: ".buildkite/scripts/build.ps1"
         key: "build-staging"
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
@@ -44,9 +43,6 @@ steps:
         env:
           DRA_WORKFLOW: "staging"
       - label: ":package: DRA Publish staging"
-        if: |
-          // Only run when triggered from Unified Release
-            ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-staging"
         depends_on: "build-staging"

--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -1,0 +1,21 @@
+###
+### The following environment variables can be set for testing purposes via the buildkite UI or CLI
+###  ONLY_AGENT: "true" - will build only the elastic-agent msi artifact
+###
+
+steps:
+  - label: ":construction_worker: Build Elastic Stack Installers Packages"
+    command: ".buildkite/scripts/build-pr.ps1"
+    key: "build-packages"
+    artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
+    agents:
+      provider: gcp
+      image: family/ci-windows-2022
+
+  - label: ":test_tube: Test Elastic Stack Installers Packages"
+    command: ".buildkite/scripts/test.ps1"
+    key: "test-packages"
+    artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
+    agents:
+      provider: gcp
+      image: family/ci-windows-2022

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,22 @@
+{
+    "jobs": [
+      {
+        "enabled": true,
+        "pipeline_slug": "elastic-stack-installers-pull-request-pipeline",
+        "allow_org_users": true,
+        "allowed_repo_permissions": ["admin", "write"],
+        "allowed_list": ["github-actions[bot]"],
+        "set_commit_status": true,
+        "build_on_commit": true,
+        "build_on_comment": true,
+        "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+        "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+        "skip_ci_labels": [ ],
+        "skip_target_branches": [ ],
+        "skip_ci_on_only_changed": [
+          "^docs/"
+        ],
+        "always_require_ci_on_changed": [ ]
+      }
+    ]
+  }

--- a/.buildkite/scripts/test.ps1
+++ b/.buildkite/scripts/test.ps1
@@ -1,46 +1,58 @@
 $ErrorActionPreference = "Stop"
 Set-Strictmode -version 3
 
-Write-Host "~~~ Running Tests"
-write-host (ConvertTo-Json $PSVersiontable -Compress)
-write-host "Running as: $([Environment]::UserName)"
+New-Item -Path "C:\users\buildkite\esi\bin\out" -ItemType Directory -Force
+Set-Location C:\users\buildkite\esi\bin\out
 
-write-host "`$env:AGENT = $($Env:AGENT)"
+echo "+++ Downloading artifacts"
+buildkite-agent artifact download 'users\buildkite\esi\bin\out\**\*.msi' .
 
-if ($psversiontable.psversion -lt "7.4.0") {
-    # Download Powershell Core, and rerun this script using Powershell Core
-    
-    write-host "Downloading Powershell Core"
-    invoke-webrequest -uri https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/PowerShell-7.4.0-win-x64.zip -outfile pwsh.zip
-    
-    write-host "Expanding Powershell Core"
-    Expand-Archive pwsh.zip -destinationpath (Join-Path $PSScriptRoot "pwsh")
-    
-    Write-host "Invoking from Powershell Core"
-    & (Join-Path $PSScriptRoot "pwsh/pwsh.exe") -file (Join-Path $PSScriptRoot "test.ps1")
+try {
+    Write-Host "~~~ Running Tests"
+    write-host (ConvertTo-Json $PSVersiontable -Compress)
+    write-host "Running as: $([Environment]::UserName)"
 
-    if ($LASTEXITCODE -eq 0) {
-        write-host "Child pwsh process exited successfully"
-        exit 0
-    } else {
-        write-host "Child pwsh process returned $LASTEXITCODE, a non zero exit code"
-        throw "Tests failed."
+    write-host "`$env:AGENT = $($Env:AGENT)"
+
+    if ($psversiontable.psversion -lt "7.4.0") {
+        # Download Powershell Core, and rerun this script using Powershell Core
+        
+        write-host "Downloading Powershell Core"
+        invoke-webrequest -uri https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/PowerShell-7.4.0-win-x64.zip -outfile pwsh.zip
+        
+        write-host "Expanding Powershell Core"
+        Expand-Archive pwsh.zip -destinationpath (Join-Path $PSScriptRoot "pwsh")
+        
+        Write-host "Invoking from Powershell Core"
+        & (Join-Path $PSScriptRoot "pwsh/pwsh.exe") -file (Join-Path $PSScriptRoot "test.ps1")
+
+        if ($LASTEXITCODE -eq 0) {
+            write-host "Child pwsh process exited successfully"
+            exit 0
+        } else {
+            write-host "Child pwsh process returned $LASTEXITCODE, a non zero exit code"
+            throw "Tests failed."
+        }
     }
+
+    $AgentMSI = Get-ChildItem bin/out -Include "elastic-agent*.msi" -Recurse
+
+    if ($AgentMSI -eq $null) {
+        write-error "No agent MSI found to test"
+    }
+
+
+    $OldAgentMSI = (Join-Path $PSScriptRoot "elastic-agent-8.11.4-windows-x86_64.msi")
+    if (-not (test-path $OldAgentMSI)) {
+        Write-Host "Downloading older MSI for upgrade tests"
+        invoke-webrequest -uri https://storage.googleapis.com/agent-msi-testing/elastic-agent-8.11.4-windows-x86_64.msi -outfile $OldAgentMSI
+    }
+
+    & (Join-Path $PSScriptRoot "../../src/agent-qa/Invoke-Pester.ps1") -PathToLatestMSI $AgentMSI.Fullname -PathToEarlyMSI $OldAgentMSI
+
+    write-host "Returned from Pester Test"
+} catch {
+        write-host "Testing Failed"
+        write-error $_
+        exit 1
 }
-
-$AgentMSI = Get-ChildItem bin/out -Include "elastic-agent*.msi" -Recurse
-
-if ($AgentMSI -eq $null) {
-    write-error "No agent MSI found to test"
-}
-
-
-$OldAgentMSI = (Join-Path $PSScriptRoot "elastic-agent-8.11.4-windows-x86_64.msi")
-if (-not (test-path $OldAgentMSI)) {
-    Write-Host "Downloading older MSI for upgrade tests"
-    invoke-webrequest -uri https://storage.googleapis.com/agent-msi-testing/elastic-agent-8.11.4-windows-x86_64.msi -outfile $OldAgentMSI
-}
-
-& (Join-Path $PSScriptRoot "../../src/agent-qa/Invoke-Pester.ps1") -PathToLatestMSI $AgentMSI.Fullname -PathToEarlyMSI $OldAgentMSI
-
-write-host "Returned from Pester Test"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -47,11 +47,9 @@ spec:
     spec:
       pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
-        build_branches: true
-        build_pull_request_forks: false
-        build_pull_requests: true
-        publish_commit_status: true
-        publish_commit_status_per_step: false
+        # this job should only be triggered from the unified release for branches >= 8.13
+        # or from the `elastic-stack-installers-trigger` cron like job for branches <8.13
+        trigger_mode: none # don't trigger jobs from github activity
       repository: elastic/elastic-stack-installers
       teams:
         everyone:
@@ -62,6 +60,51 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: elastic-stack-installers-pull-request-pipeline
+  description: 'Elastic Stack Installers Pull Request pipeline'
+  links:
+    - title: 'Elastic Stack Installers Pull Request Pipeline'
+      url: https://buildkite.com/elastic/logstash-pull-request-pipeline
+spec:
+  type: buildkite-pipeline
+  owner: group:logstash
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elastic-stack-installers-pull-request-pipeline
+      description: ':windows: Elastic Stack Installers / Pull Requests'
+    spec:
+      repository: elastic/elastic-stack-installers
+      pipeline_file: ".buildkite/pull-request-pipeline.yml"
+      maximum_timeout_in_minutes: 120
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_branches: false
+        build_tags: false
+        filter_enabled: true
+        filter_condition: >-
+          build.creator.name == 'elasticmachine' && build.pull_request.id != null
+      cancel_intermediate_builds: true
+      skip_intermediate_builds: true
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        everyone:
+          access_level: BUILD_AND_READ
+        ingest-fp: {}
+        release-eng: {}
 
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json


### PR DESCRIPTION
This commit refactors the existing
build & DRA publishing pipeline to only run
whe triggered via the unified release process
and creates a new PR dedicated pipeline which
builds packages and runs tests.

This should be backported to 8.13 but not further.

Closes https://github.com/elastic/ingest-dev/issues/2918