### PR TITLE
Don't run snapshot DRA when triggered by staging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,12 @@ steps:
       - label: ":construction_worker: Build stack installers / Snapshot"
         command: ".buildkite/scripts/build.ps1"
         key: "build-snapshot"
+        if: |
+          // Only run when triggered from Unified Release or via PRs targetting non-main, since there is no valid MANIFEST_URL for snapshot/main branch.
+          (
+            ( build.env("BUILDKITE_PULL_REQUEST") != "false" && build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ /^[0-9]+\.[0-9]+\$/ ) ||
+            ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" )
+          )
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
         agents:
           provider: gcp
@@ -19,7 +25,9 @@ steps:
       - label: ":package: DRA Publish Snapshot"
         if: |
           // Only run when triggered from Unified Release
-          ( (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" )
+          (
+            (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot"
+          )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-snapshot"
         depends_on: "build-snapshot"
@@ -29,12 +37,11 @@ steps:
           DRA_WORKFLOW: "snapshot"
   - group: ":package: Stack installers Staging"
     key: "dra-staging"
+    if: |
+      // Staging should only run when triggered from Unified Release
+        ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
-        if: |
-          // Only run when triggered from Unified Release or via PRs targetting non-main, since there is no valid MANIFEST_URL for staging/main branch.
-          ( build.env("BUILDKITE_PULL_REQUEST") != "false" && build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ /^[0-9]+\.[0-9]+\$/ ) ||
-            ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
         command: ".buildkite/scripts/build.ps1"
         key: "build-staging"
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
@@ -44,9 +51,6 @@ steps:
         env:
           DRA_WORKFLOW: "staging"
       - label: ":package: DRA Publish staging"
-        if: |
-          // Only run when triggered from Unified Release
-            ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-staging"
         depends_on: "build-staging"


### PR DESCRIPTION
This commit tightens the pipeline conditionals to ensure the snapshot job doesn't run when the unified release triggers staging.

Relates https://github.com/elastic/elastic-stack-installers/pull/244

Should be backported to 8.13 (but not further)