### PR TITLE
update snapshot conditional

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,10 @@
 steps:
   - group: ":package: Stack installers Snapshot"
     key: "dra-snapshot"
+    if: |
+      // Only run when triggered from Unified Release or via PRs targetting main or a release branch.
+      ( ( build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ ) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" ) ||
+        ( build.env("BUILDKITE_PULL_REQUEST") != "false" && build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ ^(?:[0-9]+\\.[0-9]+|main)\\$ )
     steps:
       - label: ":construction_worker: Build stack installers / Snapshot"
         command: ".buildkite/scripts/build.ps1"
@@ -17,9 +21,6 @@ steps:
         env:
           DRA_WORKFLOW: "snapshot"
       - label: ":package: DRA Publish Snapshot"
-        if: |
-          // Only run when triggered from Unified Release
-          ( (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-snapshot"
         depends_on: "build-snapshot"


### PR DESCRIPTION
Moves the conditional to the group level, and adds logic to run on prs.

The existing configuration causes the "build-snapshot" step to be wrongly invoked by the unified staging build triggers, which inevitably fails and blocks staging builds.

Signed-off-by: David Natachanny <David.Natachanny@elastic.co>