### PR TITLE
Don't run snapshot DRA publish with PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,12 @@ steps:
         env:
           DRA_WORKFLOW: "snapshot"
       - label: ":package: DRA Publish Snapshot"
-        # publish runs in dry-run mode when triggered from PRs, see .buildkite/scripts/dra-publish.sh
+        if: |
+          // Only run when triggered from Unified Release and not from PRs
+          (
+            ( build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ ) &&
+            build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot"
+          )
         command: ".buildkite/scripts/dra-publish.sh"
         key: "publish-snapshot"
         depends_on: "build-snapshot"


### PR DESCRIPTION
Even though the dra publish script attempts to
run the release manager in dry-run mode, there's
no value allowing the step to run via PRs, because it fails since it's working with an unrecognized
branch e.g. `The specified project directory '/release/project-configs/test-prs' does not exist.`

Example failure: https://buildkite.com/elastic/elastic-stack-installers/builds/3910#018dcc46-d6c9-4845-bf0f-be61a7dd307e/73-101

This commit skips the DRA publish step when the snapshot pipeline gets triggered by PRs.