### PR TITLE
Remove trailing slash and store data and logs in subfolders

### DIFF
--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -113,6 +113,12 @@ namespace Elastic.PackageCompiler.Beats
                 service = new WixSharp.File(Path.Combine(opts.PackageInDir, exeName));
                 string installedPath = ("[INSTALLDIR]");
 
+                // Trim trailing slash if present
+                if (installedPath.EndsWith("\\"))
+                {
+                    installedPath = installedPath.Substring(0, installedPath.Length - 1);
+                }
+
                 // TODO: CNDL1150 : ServiceConfig functionality is documented in the Windows Installer SDK to 
                 //                  "not [work] as expected." Consider replacing ServiceConfig with the 
                 //                  WixUtilExtension ServiceConfig element.
@@ -133,9 +139,9 @@ namespace Elastic.PackageCompiler.Beats
 
                     Arguments =
                         " --path.home " + installedPath.Quote() +
-                        " --path.config " + installedPath.Quote() +
-                        " --path.data " + installedPath.Quote() +
-                        " --path.logs " + installedPath.Quote() +
+                        " --path.config " +installedPath.Quote() +
+                        " --path.data " + (installedPath + "\data").Quote() +
+                        " --path.logs " + (installedPath + "\logs").Quote() +
                         " -E logging.files.redirect_stderr=true",
 
                     DelayedAutoStart = false,


### PR DESCRIPTION
Properly handle the fact that MSI Directories always end in a slash. This slash results in the second quote of each path being escaped thus breaking the service binpath.

Fixes: #261 
Fixes: #262

Caused by https://github.com/elastic/elastic-stack-installers/commit/6bb7be7c5527fa39d3026d4080e8cbb096e81341 in https://github.com/elastic/elastic-stack-installers/pull/209