### PR TITLE
Remove trailing slash and store data and logs in subfolders

### DIFF
--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -112,6 +112,11 @@ namespace Elastic.PackageCompiler.Beats
             {
                 service = new WixSharp.File(Path.Combine(opts.PackageInDir, exeName));
                 string installedPath = ("[INSTALLDIR]");
+                // Trim trailing slash if present
+                if (installedPath.EndsWith("\\"))
+                {
+                    installedPath = installedPath.Substring(0, installedPath.Length - 1);
+                }
 
                 // TODO: CNDL1150 : ServiceConfig functionality is documented in the Windows Installer SDK to 
                 //                  "not [work] as expected." Consider replacing ServiceConfig with the 
@@ -134,8 +139,8 @@ namespace Elastic.PackageCompiler.Beats
                     Arguments =
                         " --path.home " + installedPath.Quote() +
                         " --path.config " + installedPath.Quote() +
-                        " --path.data " + installedPath.Quote() +
-                        " --path.logs " + installedPath.Quote() +
+                        " --path.data " + (installedPath + "\\data").Quote() +
+                        " --path.logs " + (installedPath + "\\logs").Quote() +
                         " -E logging.files.redirect_stderr=true",
 
                     DelayedAutoStart = false,

--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -111,13 +111,10 @@ namespace Elastic.PackageCompiler.Beats
             if (pc.IsWindowsService)
             {
                 service = new WixSharp.File(Path.Combine(opts.PackageInDir, exeName));
+                
+                // [INSTALLDIR] is evaluated at runtime so we cannot easily manipulate it here to remove the trailing slash
                 string installedPath = ("[INSTALLDIR]");
-                // Trim trailing slash if present
-                if (installedPath.EndsWith("\\"))
-                {
-                    installedPath = installedPath.Substring(0, installedPath.Length - 1);
-                }
-
+                
                 // TODO: CNDL1150 : ServiceConfig functionality is documented in the Windows Installer SDK to 
                 //                  "not [work] as expected." Consider replacing ServiceConfig with the 
                 //                  WixUtilExtension ServiceConfig element.
@@ -137,10 +134,10 @@ namespace Elastic.PackageCompiler.Beats
                     },
 
                     Arguments =
-                        " --path.home " + installedPath.Quote() +
-                        " --path.config " + installedPath.Quote() +
-                        " --path.data " + (installedPath + "\\data").Quote() +
-                        " --path.logs " + (installedPath + "\\logs").Quote() +
+                        " --path.home " + (installedPath + ".").Quote() + // trailing dot is because installedpath ends in a slash
+                        " --path.config " + (installedPath + ".").Quote() + // trailing dot is because installedpath ends in a slash
+                        " --path.data " + (installedPath + "data").Quote() +
+                        " --path.logs " + (installedPath + "logs").Quote() +
                         " -E logging.files.redirect_stderr=true",
 
                     DelayedAutoStart = false,

--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -148,7 +148,6 @@ namespace Elastic.PackageCompiler.Beats
 
                     // Don't start on install, config file is likely not ready yet
                     //StartOn = SvcEvent.Install,
-
                     StopOn = SvcEvent.InstallUninstall_Wait,
                     RemoveOn = SvcEvent.InstallUninstall_Wait,
                 };


### PR DESCRIPTION
Properly handle the fact that MSI Directories always end in a slash. This slash results in the second quote of each path being escaped thus breaking the service binpath.

Fixes: #261 
Fixes: #262

Caused by https://github.com/elastic/elastic-stack-installers/commit/6bb7be7c5527fa39d3026d4080e8cbb096e81341 in https://github.com/elastic/elastic-stack-installers/pull/209