### PR TITLE
Use actually maintained CI VM images

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,7 +19,7 @@ steps:
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
         agents:
           provider: gcp
-          image: family/ci-windows-2022
+          image: family/core-windows-2022
         env:
           DRA_WORKFLOW: "snapshot"
       - label: ":package: DRA Publish Snapshot"
@@ -48,7 +48,7 @@ steps:
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
         agents:
           provider: gcp
-          image: family/ci-windows-2022
+          image: family/core-windows-2022
         env:
           DRA_WORKFLOW: "staging"
       - label: ":package: DRA Publish staging"


### PR DESCRIPTION
Images have been renamed a while ago, this commit updates the Windows image names used by CI.