### PR TITLE
Use actually maintained CI VM images (#276)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,7 +19,7 @@ steps:
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
         agents:
           provider: gcp
-          image: family/ci-windows-2022
+          image: family/core-windows-2022
         env:
           DRA_WORKFLOW: "snapshot"
       - label: ":package: DRA Publish Snapshot"
@@ -48,7 +48,7 @@ steps:
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
         agents:
           provider: gcp
-          image: family/ci-windows-2022
+          image: family/core-windows-2022
         env:
           DRA_WORKFLOW: "staging"
       - label: ":package: DRA Publish staging"

--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ Similarly to the install flow (described above), the MSI will call the `elastic-
 ### Upgrade
 The Agent MSI doesn't support upgrade. Since the agents are fleet managed, upgrades shall be done using fleet (UI / API).
 
- 

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ Similarly to the install flow (described above), the MSI will call the `elastic-
 ### Upgrade
 The Agent MSI doesn't support upgrade. Since the agents are fleet managed, upgrades shall be done using fleet (UI / API).
 
+ 


### PR DESCRIPTION
Images have been renamed a while ago, this commit updates the Windows image names used by CI.