### PR TITLE
Use actually maintained CI VM images (#276)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
         artifact_paths: "bin/out/**/*.msi"
         agents:
           provider: gcp
-          image: family/ci-windows-2022
+          image: family/core-windows-2022
         env:
           WORKFLOW: "snapshot"
       - label: ":package: DRA Publish Snapshot"
@@ -33,7 +33,7 @@ steps:
         artifact_paths: "bin/out/**/*.msi"
         agents:
           provider: gcp
-          image: family/ci-windows-2022
+          image: family/core-windows-2022
         env:
           WORKFLOW: "staging"
       - label: ":package: DRA Publish staging"


### PR DESCRIPTION
Images have been renamed a while ago, this commit updates the Windows image names used by CI.