### PR TITLE
allow independent-agent-release-staging for dra staging workflow

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,10 @@ steps:
     key: "dra-staging"
     if: |
       // Staging should only run when triggered from Unified Release
-        ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
+        ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && (
+            build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" ||
+            build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "independent-agent-release-staging"
+        ))
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
         command: ".buildkite/scripts/build.ps1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,7 @@ steps:
         ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && (
             build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" ||
             build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "independent-agent-release-staging"
-        ))
+        )) || ( build.branch == 'pull/281/merge' )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
         command: ".buildkite/scripts/build.ps1"

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -58,7 +58,7 @@ if (-not (Test-Path env:MANIFEST_URL) -and (Test-Path env:BUILDKITE_PULL_REQUEST
 elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and (
         ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*") -or
         ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "independent-agent-release*")
-    ) {
+    )) {
     # we got triggered by a branch push
     Write-Host "~~~ Running in branch push mode"
 

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -55,7 +55,10 @@ if (-not (Test-Path env:MANIFEST_URL) -and (Test-Path env:BUILDKITE_PULL_REQUEST
 
     setManifestUrl -targetBranch $targetBranch
 }
-elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*")) {
+elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and (
+        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*") -or
+        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "independent-agent-release*")
+    ) {
     # we got triggered by a branch push
     Write-Host "~~~ Running in branch push mode"
 

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -55,10 +55,7 @@ if (-not (Test-Path env:MANIFEST_URL) -and (Test-Path env:BUILDKITE_PULL_REQUEST
 
     setManifestUrl -targetBranch $targetBranch
 }
-elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and ( `
-        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*") -or `
-        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "independent-agent-release*") `
-    )) {
+elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and ( ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*") -or ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "independent-agent-release*") )) {
     # we got triggered by a branch push
     Write-Host "~~~ Running in branch push mode"
 

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -55,9 +55,9 @@ if (-not (Test-Path env:MANIFEST_URL) -and (Test-Path env:BUILDKITE_PULL_REQUEST
 
     setManifestUrl -targetBranch $targetBranch
 }
-elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and (
-        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*") -or
-        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "independent-agent-release*")
+elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and ( `
+        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*") -or `
+        ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "independent-agent-release*") `
     )) {
     # we got triggered by a branch push
     Write-Host "~~~ Running in branch push mode"

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -23,7 +23,7 @@ export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 # Retrieve version value
 VERSION=$(curl -s --retry 5 --retry-delay 10 "$MANIFEST_URL" | jq -r '.version')
 # remove -SNAPSHOT style suffix from VERSION
-VERSION=${VERSION%-*}
+VERSION=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
 export VERSION
 if [[ -z $VERSION ]]; then
     echo "+++ Required version property from ${MANIFEST_URL} was empty: [$VERSION]. Exiting."

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -17,7 +17,7 @@ DRA_CREDS=$(vault kv get -field=data -format=json kv/ci-shared/release/dra-role)
 VAULT_ADDR=$(echo $DRA_CREDS | jq -r '.vault_addr')
 VAULT_ROLE_ID=$(echo $DRA_CREDS | jq -r '.role_id')
 VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id') 
-BRANCH="${BUILDKITE_BRANCH}"
+BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
 export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 
 # Retrieve version value
@@ -39,10 +39,7 @@ fi
 # Publish DRA artifacts
 function run_release_manager() {
     echo "+++ Publishing $BUILDKITE_BRANCH ${DRA_WORKFLOW} DRA artifacts..."
-    dry_run=""
-    if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
-        dry_run="--dry-run"
-    fi
+    dry_run="--dry-run"
     docker run --rm \
         --name release-manager \
         -e VAULT_ADDR="${VAULT_ADDR}" \

--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -40,10 +40,11 @@ namespace Elastic.PackageCompiler.Beats
             // Generate UUID v5 from product properties.
             // This UUID *must* be stable and unique between Beats.
             var upgradeCode = Uuid5.FromString(ap.CanonicalTargetName);
+            string version = SupportBuildVersionForAgent(ap.Version);
 
             var project = new Project(displayName)
             {
-                InstallerVersion = 500,
+                InstallerVersion = 500, 
 
                 GUID = upgradeCode,
 
@@ -52,7 +53,7 @@ namespace Elastic.PackageCompiler.Beats
                 Description = pc.Description,
 
                 OutFileName = Path.Combine(opts.PackageOutDir, opts.PackageName),
-                Version = new Version(ap.Version),
+                Version = new Version(version),
 
                 // We massage LICENSE.txt into .rtf below
                 LicenceFile = Path.Combine(
@@ -289,6 +290,22 @@ namespace Elastic.PackageCompiler.Beats
         Value=""CA_SelectExampleYamlInExplorer"">WIXUI_EXITDIALOGOPTIONALCHECKBOX=1 and NOT Installed
     </Publish>
 </UI>"));
+        }
+
+        private static string SupportBuildVersionForAgent(string originalVersion)
+        {
+            if (!originalVersion.Contains("+build"))
+                return originalVersion;
+
+            string version = originalVersion.Replace("+build", ".");
+            string[] arr = version.Split(new char[] { '.' });
+            if (arr.Length == 4 && arr[3].Length > 4)
+            {
+                arr[3] = arr[3].Substring(4);
+                return arr.Join(".");
+            }
+
+            return originalVersion;
         }
 
         private static void RenameConfigFile(CmdLineOptions opts, ArtifactPackage ap, List<WixEntity> packageContents, string beatConfigExampleFileName, string beatConfigExampleFileId)

--- a/src/installer/BeatPackageCompiler/Properties/launchSettings.json
+++ b/src/installer/BeatPackageCompiler/Properties/launchSettings.json
@@ -29,6 +29,11 @@
       "commandName": "Project",
       "commandLineArgs": "--package=winlogbeat-8.12.1-windows-x86_64 -v --keep-temp-files",
       "workingDirectory": "$(SolutionDir)"
+    },
+    "Agent with custom build": {
+      "commandName": "Project",
+      "commandLineArgs": "--package=elastic-agent-8.14.0+build202407021002-windows-x86_64 -v --keep-temp-files",
+      "workingDirectory": "$(SolutionDir)"
     }
   }
 }

--- a/src/shared/ArtifactPackage.cs
+++ b/src/shared/ArtifactPackage.cs
@@ -38,7 +38,7 @@ namespace Elastic.Installer
         static readonly Regex rx = new Regex(
             /* 0 full capture, 7 groups total */
             /* 1 */ @$"(?<target>[^-]+({MagicStrings.Files.DashOssSuffix})?)" +
-            /* 2 */ @$"-(?<version>\d+\.\d+\.\d+)" +
+            /* 2 */ @$"-(?<version>\d+\.\d+\.\d+(?:\+build\d+)?)" +
             /* 3 */ @$"(-(?<qualifier>(?!\b(?:{MagicStrings.Ver.Snapshot})\b)[^-]+))?" +
             /* 4 */ @$"(-(?<snapshot>{MagicStrings.Ver.Snapshot}))?" +
             /* 5 */ @$"-(?<os>[^-]+)" +

--- a/src/shared/QualifiedVersion.cs
+++ b/src/shared/QualifiedVersion.cs
@@ -32,7 +32,7 @@ namespace Elastic.Installer
 
         static readonly Regex rx = new Regex(
             /* 0 full capture, 4 groups total */
-            /* 1 */ @$"(?<version>\d+\.\d+(\.\d+)?)" +
+            /* 1 */ @$"(?<version>\d+\.\d+(\.\d+)?(?:\+build\d+)?)" +
             /* 2 */ @$"(-(?<qualifier>(?!\b(?:{MagicStrings.Ver.Snapshot})\b)[^-]+))?" +
             /* 3 */ @$"(-(?<snapshot>{MagicStrings.Ver.Snapshot}))?",
             RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);


### PR DESCRIPTION
This PR allows [independent-agent-release-staging](https://buildkite.com/elastic/independent-agent-release-staging) to trigger Stack installers Staging workflow.

Independent Agent Release needs to include Windows installer. Our intent is to only include Agent binary.
