### PR TITLE
Add Independent Agent alternate step in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,7 @@ steps:
     key: "independent-agent-staging"
     if: |
       // This should only run when triggered from Independent Agent Staging
-        build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") != "independent-agent-release-staging"
+        (build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "independent-agent-release-staging") || ( build.branch == 'pull/286/merge')
     steps:
       - label: ":construction_worker: Build stack installers / Independent Agent Staging"
         command: ".buildkite/scripts/build.ps1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,7 +74,7 @@ steps:
           image: family/core-windows-2022
         env:
           DRA_WORKFLOW: "staging"
-      - label: ":package: DRA Publish staging"
+      - label: ":package: Publishing via BK API for Independent Agent Release"
         command: ".buildkite/scripts/ind-agent-publish.sh"
         key: "publish-staging-independent-agent"
         artifact_paths: "stack-installers-output/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,7 @@ steps:
     key: "independent-agent-staging"
     if: |
       // This should only run when triggered from Independent Agent Staging
-        (build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "independent-agent-release-staging") || ( build.branch == 'pull/286/merge')
+        (build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "independent-agent-release-staging")
     steps:
       - label: ":construction_worker: Build stack installers / Independent Agent Staging"
         command: ".buildkite/scripts/build.ps1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,3 +59,27 @@ steps:
           provider: gcp
         env:
           DRA_WORKFLOW: "staging"
+  - group: ":package: Stack installers Independent Agent Staging"
+    key: "independent-agent-staging"
+    if: |
+      // This should only run when triggered from Independent Agent Staging
+        build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") != "independent-agent-release-staging"
+    steps:
+      - label: ":construction_worker: Build stack installers / Independent Agent Staging"
+        command: ".buildkite/scripts/build.ps1"
+        key: "build-staging-independent-agent"
+        artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
+        agents:
+          provider: gcp
+          image: family/core-windows-2022
+        env:
+          DRA_WORKFLOW: "staging"
+      - label: ":package: DRA Publish staging"
+        command: ".buildkite/scripts/ind-agent-publish.sh"
+        key: "publish-staging-independent-agent"
+        artifact_paths: "stack-installers-output/**/*"
+        depends_on: "build-staging-independent-agent"
+        agents:
+          provider: gcp
+        env:
+          DRA_WORKFLOW: "staging"

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -55,7 +55,7 @@ if (-not (Test-Path env:MANIFEST_URL) -and (Test-Path env:BUILDKITE_PULL_REQUEST
 
     setManifestUrl -targetBranch $targetBranch
 }
-elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*")) {
+elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigger_job") -and (($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "unified-release*") -or ($env:BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG -notlike "independent-agent-release*"))) {
     # we got triggered by a branch push
     Write-Host "~~~ Running in branch push mode"
 

--- a/.buildkite/scripts/ind-agent-publish.sh
+++ b/.buildkite/scripts/ind-agent-publish.sh
@@ -8,14 +8,19 @@ echo "+++ Downloading artifacts..."
 # but it's an experimental feature that needs an agent flag set: https://buildkite.com/docs/agent/v3#experimental-features-normalised-upload-paths
 buildkite-agent artifact download 'users\buildkite\esi\bin\out\**\*.msi' . --step "build-${DRA_WORKFLOW}-independent-agent"
 
+echo "--- Creating output dir and moving files there"
 OUTPUT_DIR="stack-installers-output"
 mkdir "$OUTPUT_DIR"
 mv users/buildkite/esi/bin "$OUTPUT_DIR"
 chmod -R 777 "$OUTPUT_DIR"
 
+echo "--- ls -alR"
+ls -alR "${OUTPUT_DIR}"
+
 # Create sha512 for msi file(s)
 # We can leave it as this loop in order to account for a possible future ARM msi
-pushd "${OUTPUT_DIR}/out/elastic"
+echo "--- Creating sha512 files"
+pushd "${OUTPUT_DIR}/bin/out/elastic"
 for f in *.msi; do 
     sha512sum "${f}" > "${f}.sha512"
 done
@@ -24,7 +29,7 @@ done
 
 # Check and set trigger id
 if [[ -z "${TRIGGER_JOB_ID}" ]]; then
-    echo "TRIGGER_JOB_ID is not set, so not setting metadata"
+    echo "--- TRIGGER_JOB_ID is not set, so not setting metadata"
 else
     # If a pipeline that triggered this build passes in a "TRIGGER_JOB_ID" env var, that
     # is an indicator that it will want us to set some metadata in that calling build
@@ -34,64 +39,7 @@ else
     # This is a much easier way to pull back artifacts from a triggered build than using
     # a Buildkite token that we then have to manage via vault, etc.
     # See: https://forum.buildkite.community/t/how-to-download-artifacts-back-from-triggered-pipeline/3480/2
-    echo "Setting metadata for job that trigger this one"
+    echo "--- Setting metadata for job that trigger this one"
     buildkite-agent meta-data set "triggered_build_id" "$BUILDKITE_BUILD_ID" --job $TRIGGER_JOB_ID
     buildkite-agent meta-data set "triggered_commit_hash" "$BUILDKITE_COMMIT" --job $TRIGGER_JOB_ID
 fi
-
-
-echo "+++ Setting DRA params" 
-# Shared secret path containing the dra creds for project teams
-DRA_CREDS=$(vault kv get -field=data -format=json kv/ci-shared/release/dra-role)
-VAULT_ADDR=$(echo $DRA_CREDS | jq -r '.vault_addr')
-VAULT_ROLE_ID=$(echo $DRA_CREDS | jq -r '.role_id')
-VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id') 
-BRANCH="${BUILDKITE_BRANCH}"
-export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
-
-# Retrieve version value
-VERSION=$(curl -s --retry 5 --retry-delay 10 "$MANIFEST_URL" | jq -r '.version')
-# remove -SNAPSHOT style suffix from VERSION
-VERSION=${VERSION%-*}
-export VERSION
-if [[ -z $VERSION ]]; then
-    echo "+++ Required version property from ${MANIFEST_URL} was empty: [$VERSION]. Exiting."
-    exit 1
-fi
-
-if [ "$DRA_WORKFLOW" == "staging" ]; then
-    BEATS_MANIFEST_URL=$(curl https://artifacts-"$DRA_WORKFLOW".elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
-else
-    BEATS_MANIFEST_URL=$(curl https://artifacts-"$DRA_WORKFLOW".elastic.co/beats/latest/"$VERSION"-SNAPSHOT.json | jq -r '.manifest_url')
-fi
-
-# Publish DRA artifacts
-function run_release_manager() {
-    echo "+++ Publishing $BUILDKITE_BRANCH ${DRA_WORKFLOW} DRA artifacts..."
-    dry_run=""
-    if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
-        dry_run="--dry-run"
-    fi
-    docker run --rm \
-        --name release-manager \
-        -e VAULT_ADDR="${VAULT_ADDR}" \
-        -e VAULT_ROLE_ID="${VAULT_ROLE_ID}" \
-        -e VAULT_SECRET_ID="${VAULT_SECRET_ID}" \
-        --mount type=bind,readonly=false,src="${PWD}",target=/artifacts \
-        docker.elastic.co/infra/release-manager:latest \
-        cli collect \
-        --project elastic-stack-installers \
-        --branch "${BRANCH}" \
-        --commit "${BUILDKITE_COMMIT}" \
-        --workflow "${DRA_WORKFLOW}" \
-        --version "${VERSION}" \
-        --artifact-set main \
-        --dependency beats:"${BEATS_MANIFEST_URL}" \
-        $dry_run \
-        #
-}
-
-run_release_manager
-RM_EXIT_CODE=$?
-
-exit $RM_EXIT_CODE

--- a/.buildkite/scripts/ind-agent-publish.sh
+++ b/.buildkite/scripts/ind-agent-publish.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Download artifacts from Buildkite "Build stack installers" step
+echo "+++ Downloading artifacts..."
+# it's possible to also use unix style paths for download (users/buildkites/...)
+# but it's an experimental feature that needs an agent flag set: https://buildkite.com/docs/agent/v3#experimental-features-normalised-upload-paths
+buildkite-agent artifact download 'users\buildkite\esi\bin\out\**\*.msi' . --step "build-${DRA_WORKFLOW}-independent-agent"
+
+OUTPUT_DIR="stack-installers-output"
+mkdir "$OUTPUT_DIR"
+mv users/buildkite/esi/bin "$OUTPUT_DIR"
+chmod -R 777 "$OUTPUT_DIR"
+
+# Create sha512 for msi file(s)
+# We can leave it as this loop in order to account for a possible future ARM msi
+pushd "${OUTPUT_DIR}/out/elastic"
+for f in *.msi; do 
+    sha512sum "${f}" > "${f}.sha512"
+done
+
+# The defined "artifacts_path" will pick up "stack-installers-output/**/*"
+
+# Check and set trigger id
+if [[ -z "${TRIGGER_JOB_ID}" ]]; then
+    echo "TRIGGER_JOB_ID is not set, so not setting metadata"
+else
+    # If a pipeline that triggered this build passes in a "TRIGGER_JOB_ID" env var, that
+    # is an indicator that it will want us to set some metadata in that calling build
+    # so that it can reference this specific build ID in order to easily download
+    # artifacts saved off in this build.
+    #
+    # This is a much easier way to pull back artifacts from a triggered build than using
+    # a Buildkite token that we then have to manage via vault, etc.
+    # See: https://forum.buildkite.community/t/how-to-download-artifacts-back-from-triggered-pipeline/3480/2
+    echo "Setting metadata for job that trigger this one"
+    buildkite-agent meta-data set "triggered_build_id" "$BUILDKITE_BUILD_ID" --job $TRIGGER_JOB_ID
+    buildkite-agent meta-data set "triggered_commit_hash" "$BUILDKITE_COMMIT" --job $TRIGGER_JOB_ID
+fi
+
+
+echo "+++ Setting DRA params" 
+# Shared secret path containing the dra creds for project teams
+DRA_CREDS=$(vault kv get -field=data -format=json kv/ci-shared/release/dra-role)
+VAULT_ADDR=$(echo $DRA_CREDS | jq -r '.vault_addr')
+VAULT_ROLE_ID=$(echo $DRA_CREDS | jq -r '.role_id')
+VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id') 
+BRANCH="${BUILDKITE_BRANCH}"
+export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
+
+# Retrieve version value
+VERSION=$(curl -s --retry 5 --retry-delay 10 "$MANIFEST_URL" | jq -r '.version')
+# remove -SNAPSHOT style suffix from VERSION
+VERSION=${VERSION%-*}
+export VERSION
+if [[ -z $VERSION ]]; then
+    echo "+++ Required version property from ${MANIFEST_URL} was empty: [$VERSION]. Exiting."
+    exit 1
+fi
+
+if [ "$DRA_WORKFLOW" == "staging" ]; then
+    BEATS_MANIFEST_URL=$(curl https://artifacts-"$DRA_WORKFLOW".elastic.co/beats/latest/"$VERSION".json | jq -r '.manifest_url')
+else
+    BEATS_MANIFEST_URL=$(curl https://artifacts-"$DRA_WORKFLOW".elastic.co/beats/latest/"$VERSION"-SNAPSHOT.json | jq -r '.manifest_url')
+fi
+
+# Publish DRA artifacts
+function run_release_manager() {
+    echo "+++ Publishing $BUILDKITE_BRANCH ${DRA_WORKFLOW} DRA artifacts..."
+    dry_run=""
+    if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then
+        dry_run="--dry-run"
+    fi
+    docker run --rm \
+        --name release-manager \
+        -e VAULT_ADDR="${VAULT_ADDR}" \
+        -e VAULT_ROLE_ID="${VAULT_ROLE_ID}" \
+        -e VAULT_SECRET_ID="${VAULT_SECRET_ID}" \
+        --mount type=bind,readonly=false,src="${PWD}",target=/artifacts \
+        docker.elastic.co/infra/release-manager:latest \
+        cli collect \
+        --project elastic-stack-installers \
+        --branch "${BRANCH}" \
+        --commit "${BUILDKITE_COMMIT}" \
+        --workflow "${DRA_WORKFLOW}" \
+        --version "${VERSION}" \
+        --artifact-set main \
+        --dependency beats:"${BEATS_MANIFEST_URL}" \
+        $dry_run \
+        #
+}
+
+run_release_manager
+RM_EXIT_CODE=$?
+
+exit $RM_EXIT_CODE

--- a/.buildkite/scripts/ind-agent-publish.sh
+++ b/.buildkite/scripts/ind-agent-publish.sh
@@ -28,7 +28,7 @@ done
 # The defined "artifacts_path" will pick up "stack-installers-output/**/*"
 
 # Check and set trigger id
-if [[ -z "${TRIGGER_JOB_ID}" ]]; then
+if [[ -z "${TRIGGER_JOB_ID-}" ]]; then
     echo "--- TRIGGER_JOB_ID is not set, so not setting metadata"
 else
     # If a pipeline that triggered this build passes in a "TRIGGER_JOB_ID" env var, that

--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -40,6 +40,7 @@ namespace Elastic.PackageCompiler.Beats
             // Generate UUID v5 from product properties.
             // This UUID *must* be stable and unique between Beats.
             var upgradeCode = Uuid5.FromString(ap.CanonicalTargetName);
+            string version = SupportBuildVersionForAgent(ap.Version);
 
             var project = new Project(displayName)
             {
@@ -52,7 +53,7 @@ namespace Elastic.PackageCompiler.Beats
                 Description = pc.Description,
 
                 OutFileName = Path.Combine(opts.PackageOutDir, opts.PackageName),
-                Version = new Version(ap.Version),
+                Version = new Version(version),
 
                 // We massage LICENSE.txt into .rtf below
                 LicenceFile = Path.Combine(
@@ -289,6 +290,22 @@ namespace Elastic.PackageCompiler.Beats
         Value=""CA_SelectExampleYamlInExplorer"">WIXUI_EXITDIALOGOPTIONALCHECKBOX=1 and NOT Installed
     </Publish>
 </UI>"));
+        }
+
+        private static string SupportBuildVersionForAgent(string originalVersion)
+        {
+            if (!originalVersion.Contains("+build"))
+                return originalVersion;
+
+            string version = originalVersion.Replace("+build", ".");
+            string[] arr = version.Split(new char[] { '.' });
+            if (arr.Length == 4 && arr[3].Length > 4)
+            {
+                arr[3] = arr[3].Substring(4);
+                return arr.Join(".");
+            }
+
+            return originalVersion;
         }
 
         private static void RenameConfigFile(CmdLineOptions opts, ArtifactPackage ap, List<WixEntity> packageContents, string beatConfigExampleFileName, string beatConfigExampleFileId)

--- a/src/installer/BeatPackageCompiler/Properties/launchSettings.json
+++ b/src/installer/BeatPackageCompiler/Properties/launchSettings.json
@@ -29,6 +29,11 @@
       "commandName": "Project",
       "commandLineArgs": "--package=winlogbeat-8.12.1-windows-x86_64 -v --keep-temp-files",
       "workingDirectory": "$(SolutionDir)"
+    },
+    "Agent with custom build": {
+      "commandName": "Project",
+      "commandLineArgs": "--package=elastic-agent-8.14.0+build202407021002-windows-x86_64 -v --keep-temp-files",
+      "workingDirectory": "$(SolutionDir)"
     }
   }
 }

--- a/src/shared/ArtifactPackage.cs
+++ b/src/shared/ArtifactPackage.cs
@@ -38,7 +38,7 @@ namespace Elastic.Installer
         static readonly Regex rx = new Regex(
             /* 0 full capture, 7 groups total */
             /* 1 */ @$"(?<target>[^-]+({MagicStrings.Files.DashOssSuffix})?)" +
-            /* 2 */ @$"-(?<version>\d+\.\d+\.\d+)" +
+            /* 2 */ @$"-(?<version>\d+\.\d+\.\d+(?:\+build\d+)?)" +
             /* 3 */ @$"(-(?<qualifier>(?!\b(?:{MagicStrings.Ver.Snapshot})\b)[^-]+))?" +
             /* 4 */ @$"(-(?<snapshot>{MagicStrings.Ver.Snapshot}))?" +
             /* 5 */ @$"-(?<os>[^-]+)" +

--- a/src/shared/QualifiedVersion.cs
+++ b/src/shared/QualifiedVersion.cs
@@ -32,7 +32,7 @@ namespace Elastic.Installer
 
         static readonly Regex rx = new Regex(
             /* 0 full capture, 4 groups total */
-            /* 1 */ @$"(?<version>\d+\.\d+(\.\d+)?)" +
+            /* 1 */ @$"(?<version>\d+\.\d+(\.\d+)?(?:\+build\d+)?)" +
             /* 2 */ @$"(-(?<qualifier>(?!\b(?:{MagicStrings.Ver.Snapshot})\b)[^-]+))?" +
             /* 3 */ @$"(-(?<snapshot>{MagicStrings.Ver.Snapshot}))?",
             RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);


### PR DESCRIPTION
This PR adds an alternate step in the `elastic-stack-installers` that the Independent Agent Release will use in order to get only the Elastic Agent windows installer (`.msi`) built.

The new pipeline step uses a new script that does the following:
 * Retrieve the MSI artifacts from the Build step
 * Moves the MSI artifacts to a new directory
 * Creates a `.sha512` file for the MSI file
 * Saves the MSI and `.sha512` artifacts using Buildkite's built-in upload functionality
 * Sets metadata in the calling pipeline if the `TRIGGER_JOB_ID` is set
   * The calling pipeline will then use this metadata to download the saved artifacts

This PR incorporates the changes from these two PRs, which should be closed in favor of this PR:
 * https://github.com/elastic/elastic-stack-installers/pull/285
 * https://github.com/elastic/elastic-stack-installers/pull/281

I tested this PR with [this unified-release PR](https://github.com/elastic/unified-release/pull/1004), and verified that the Independent Agent Staging pipeline successfully triggers this new pipeline step, and is able to download the MSI and `.sha512` artifacts after this triggered pipeline finishes running.

Example of successful execution: 
 * Ind Agent Staging pipeline: https://buildkite.com/elastic/independent-agent-release-staging/builds/271
 * Triggered `elastic-stack-installers` pipeline for this PR triggered by the above pipeline: https://buildkite.com/elastic/elastic-stack-installers/builds/5635