### PR TITLE
Backport #302 to 8.x: Support prereleases (#302)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
     key: "dra-staging"
     if: |
       // Staging should only run when triggered from Unified Release
-        ( build.branch =~ /^[0-9]+\.[0-9x]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
+        ( (build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env('VERSION_QUALIFIER') != null) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
         command: ".buildkite/scripts/build.ps1"


### PR DESCRIPTION
This commit adds support for VERSION_QUALIFIER to DRA.

This commit was cherry picked from b0e45db2a4ddbdebf5e0f9c4974ad8ecf12d9ea7