### PR TITLE
Backport #302 to 8.17: Support prereleases (#302)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,8 +9,8 @@ steps:
     if: |
       // Only run when triggered from Unified Release or via PRs targetting main or release branches
       (
-        ( ( build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ ) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" ) ||
-        ( build.env("BUILDKITE_PULL_REQUEST") != "false" && ( build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") == 'main' || build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ /^[0-9]+\.[0-9]+\$/ ) )
+        ( ( build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ ) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot" ) ||
+        ( build.env("BUILDKITE_PULL_REQUEST") != "false" && ( build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") == 'main' || build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") =~ /^[0-9]+\.[0-9x]+\$/ ) )
       )
     steps:
       - label: ":construction_worker: Build stack installers / Snapshot"
@@ -26,7 +26,7 @@ steps:
         if: |
           // Only run when triggered from Unified Release and not from PRs
           (
-            ( build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ ) &&
+            ( build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ ) &&
             build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-snapshot"
           )
         command: ".buildkite/scripts/dra-publish.sh"
@@ -40,7 +40,7 @@ steps:
     key: "dra-staging"
     if: |
       // Staging should only run when triggered from Unified Release
-        ( build.branch =~ /^[0-9]+\.[0-9]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
+        ( build.branch =~ /^[0-9]+\.[0-9x]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
         command: ".buildkite/scripts/build.ps1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
     key: "dra-staging"
     if: |
       // Staging should only run when triggered from Unified Release
-        ( build.branch =~ /^[0-9]+\.[0-9x]+\$/ && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
+        ( (build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env('VERSION_QUALIFIER') != null) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
         command: ".buildkite/scripts/build.ps1"

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 Set-Strictmode -version 3
 
-$eligibleReleaseBranchesMajorMinor = "^[89]+\.[0-9]+"
+$eligibleReleaseBranchesMajorMinor = "^[89]+\.[0-9x]+"
 $runTests = $true
 
 


### PR DESCRIPTION
Support prereleases (https://github.com/elastic/elastic-stack-installers/pull/302)

This commit adds support for VERSION_QUALIFIER to DRA.

Backport from commit b0e45db2a4ddbdebf5e0f9c4974ad8ecf12d9ea7