### PR TITLE
Backport 307 to 8.16: Use centralized version qualifier (#307)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,9 @@ steps:
         ( (build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env('VERSION_QUALIFIER') != null) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
-        command: ".buildkite/scripts/build.ps1"
+        command: |
+          . ./buildkite/scripts/version_qualifier.ps1
+          .buildkite/scripts/build.ps1
         key: "build-staging"
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"
         agents:
@@ -52,7 +54,9 @@ steps:
         env:
           DRA_WORKFLOW: "staging"
       - label: ":package: DRA Publish staging"
-        command: ".buildkite/scripts/dra-publish.sh"
+        command: |
+          source .buildkite/scripts/version_qualifier.sh
+          .buildkite/scripts/dra-publish.sh
         key: "publish-staging"
         depends_on: "build-staging"
         agents:

--- a/.buildkite/scripts/version_qualifier.ps1
+++ b/.buildkite/scripts/version_qualifier.ps1
@@ -1,0 +1,26 @@
+# An opinionated approach to managing the Elastic Qualifier for the DRA in a Google Bucket
+# instead of using a Buildkite env variable.
+
+if ($env:VERSION_QUALIFIER) {
+    Write-Host "~~~ VERSION_QUALIFIER externally set to [$env:VERSION_QUALIFIER]"
+    return
+}
+
+# DRA_BRANCH can be used for manually testing packaging with PRs
+# e.g. define `DRA_BRANCH="main"` under Options/Environment Variables in the Buildkite UI after clicking new Build
+$BRANCH = if ($env:DRA_BRANCH) { $env:DRA_BRANCH } else { $env:BUILDKITE_BRANCH }
+
+$qualifier = ""
+$URL = "https://storage.googleapis.com/dra-qualifier/$BRANCH"
+
+try {
+    $response = Invoke-WebRequest -Uri $URL -UseBasicParsing -ErrorAction Stop
+    if ($response.StatusCode -eq 200) {
+        $qualifier = $response.Content.Trim()
+    }
+} catch {
+    Write-Host "Warning: Could not retrieve qualifier from $URL" -ForegroundColor Yellow
+}
+
+$env:VERSION_QUALIFIER = $qualifier
+Write-Host "~~~ VERSION_QUALIFIER set to [$env:VERSION_QUALIFIER]"

--- a/.buildkite/scripts/version_qualifier.sh
+++ b/.buildkite/scripts/version_qualifier.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# An opinionated approach to managing the Elastic Qualifier for the DRA in a Google Bucket
+# instead of using a Buildkite env variable.
+
+if [[ -n "$VERSION_QUALIFIER" ]]; then
+  echo "~~~ VERSION_QUALIFIER externally set to [$VERSION_QUALIFIER]"
+  return 0
+fi
+
+# DRA_BRANCH can be used for manually testing packaging with PRs
+# e.g. define `DRA_BRANCH="main"` under Options/Environment Variables in the Buildkite UI after clicking new Build
+BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
+
+qualifier=""
+URL="https://storage.googleapis.com/dra-qualifier/${BRANCH}"
+if curl -sf -o /dev/null "$URL" ; then
+  qualifier=$(curl -s "$URL")
+fi
+
+export VERSION_QUALIFIER="$qualifier"
+echo "~~~ VERSION_QUALIFIER set to [$VERSION_QUALIFIER]"


### PR DESCRIPTION
To avoid specifying the version qualifier for prereleases when using manually triggered builds, in this commit we leverage a centralized version of truth for the version qualifier.

This is a backport of commit be24593 to 8.16