### PR TITLE
Backport #313 to 8.x: Fix sourcing of version_qualifier.ps1 in CI (#313)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,7 +44,7 @@ steps:
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
         command: |
-          . ./buildkite/scripts/version_qualifier.ps1
+          . .buildkite/scripts/version_qualifier.ps1
           .buildkite/scripts/build.ps1
         key: "build-staging"
         artifact_paths: "c:/users/buildkite/esi/bin/out/**/*.msi"


### PR DESCRIPTION
This commit is cherry picked from 811b64ea12be5ee5a1cd3f40f46e2ce78c92ad82