### PR TITLE
Backport #314 to 8.16: Provide a way to manually run staging builds (#314)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
     key: "dra-staging"
     if: |
       // Staging should only run when triggered from Unified Release
-        ( (build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env('VERSION_QUALIFIER') != null) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
+        build.env("RUN_STAGING") == "true" || ( (build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env('VERSION_QUALIFIER') != null) && build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "unified-release-staging" )
     steps:
       - label: ":construction_worker: Build stack installers / Staging"
         command: |


### PR DESCRIPTION
This commit introduces an optional BK env var RUN_STAGING that allows manually triggering builds (for tests).

This commit is cherry-picked from 6fbe771c593b382e9f01529d127ec488460e767a