### PR TITLE
Backport #332 to 8.18: Update CODEOWNERS (#332)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 * @elastic/ingest-tech-lead
 
-/.buildkite @elastic/ingest-eng-prod
-/catalog-info.yml @elastic/ingest-eng-prod
+/.buildkite @elastic/observablt-ci @elastic/observablt-ci-contractors
+/catalog-info.yml @elastic/observablt-ci @elastic/observablt-ci-contractors


### PR DESCRIPTION
Cherry pick of 7ed5043c99ddd3eef9187d978070061d4e99f563 to 8.18

We are deprecating the GH team called `ingest-eng-prod`:

For such, we are now using two GH teams:
- @elastic/observablt-ci 
- @elastic/observablt-ci-contractors