### PR TITLE
[Agent] Add ability to build MSI for elastic-agent for arm64

### DIFF
--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -152,7 +152,7 @@ try {
 
 Remove-Item bin/out -Recurse -Force -ErrorAction Ignore
 
-Write-Output "--- Building $workflow msi"
+# Common CLI args
 $cliArgs = @(
     "run",
     "--project",
@@ -164,12 +164,37 @@ $cliArgs = @(
     "--cid",
     $version
 )
-$cliArgs += "elastic-agent"
-if ($onlyAgent -ne "true") {
-    $cliArgs += ($beats + $ossBeats)
+
+# Elastic Agent is the only artifact (currently) needing an ARM64 MSI build
+$buildArch = "arm64"
+$armAgentCliArgs = $cliArgs + @(
+    "--arch",
+    $buildArch,
+    "elastic-agent"
+)
+
+Write-Output "--- Building $workflow elastic-agent msi for $buildArch"
+&dotnet $armAgentCliArgs
+if ($LastExitcode -ne 0) {
+    Write-Error "Build $workflow elastic-agent msi for $buildArch failed with exit code $LastExitcode"
+    exit $LastExitcode
+} else {
+    Write-Output "Build $workflow elastic-agent msi for $buildArch completed with exit code $LastExitcode"
 }
 
-&dotnet $cliArgs
+# Now build the rest of the artifacts for x86_64
+$buildArch = "x86_64"
+$x64CliArgs = $cliArgs + @(
+    "--arch",
+    $buildArch,
+    "elastic-agent"
+)
+if ($onlyAgent -ne "true") {
+    $x64CliArgs += ($beats + $ossBeats)
+}
+
+Write-Output "--- Building $workflow msi for $buildArch"
+&dotnet $x64CliArgs
 if ($LastExitcode -ne 0) {
     Write-Error "Build $workflow failed with exit code $LastExitcode"
     exit $LastExitcode
@@ -180,7 +205,8 @@ if ($LastExitcode -ne 0) {
 Write-Output "--- Checking that all artifacts are there"
 $msiCount = Get-ChildItem bin/out -Include "*.msi" -Recurse | Measure-Object | Select-Object -ExpandProperty Count
 
-$expected = 1
+# always expect 2 elastic-agent (x86_64 + arm64)
+$expected = 2
 if ($onlyAgent -ne "true") {
     $expected += (2 * $beats.Length)
 }

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -67,9 +67,7 @@ elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigg
         throw $errorMessage
     }
 
-    # XXX: TEMP DO NOT MERGE
-    # setManifestUrl -targetBranch $targetBranch
-    setManifestUrl -targetBranch "9.2"
+    setManifestUrl -targetBranch $targetBranch
 }
 elseif (-not (Test-Path env:MANIFEST_URL)) {
     # any other invocation of this script (e.g. from unified release) must supply MANIFEST_URL

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -120,6 +120,7 @@ try {
     $packageName = "elastic-agent"
     $projectName = "$packageName-package"
     $urls += $json.projects.$projectName.packages."$packageName-$version-windows-x86_64.zip".url
+    $urls += $json.projects.$projectName.packages."$packageName-$version-windows-arm64.zip".url
 
     if ($onlyAgent -eq "true") {
         Write-Output "Skipping beats because env var ONLY_AGENT is set to [$env:ONLY_AGENT]"

--- a/.buildkite/scripts/build.ps1
+++ b/.buildkite/scripts/build.ps1
@@ -67,7 +67,9 @@ elseif (-not (Test-Path env:MANIFEST_URL) -and ($env:BUILDKITE_SOURCE -ne "trigg
         throw $errorMessage
     }
 
-    setManifestUrl -targetBranch $targetBranch
+    # XXX: TEMP DO NOT MERGE
+    # setManifestUrl -targetBranch $targetBranch
+    setManifestUrl -targetBranch "9.2"
 }
 elseif (-not (Test-Path env:MANIFEST_URL)) {
     # any other invocation of this script (e.g. from unified release) must supply MANIFEST_URL

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -11,15 +11,18 @@ buildkite-agent artifact download 'users\buildkite\esi\bin\out\**\*.msi' . --ste
 mv users/buildkite/esi/bin bin
 chmod -R 777 bin/out
 
-echo "+++ Setting DRA params" 
+echo "+++ Setting DRA params"
 # Shared secret path containing the dra creds for project teams
 DRA_CREDS=$(vault kv get -field=data -format=json kv/ci-shared/release/dra-role)
 VAULT_ADDR=$(echo $DRA_CREDS | jq -r '.vault_addr')
 VAULT_ROLE_ID=$(echo $DRA_CREDS | jq -r '.role_id')
-VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id') 
+VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id')
 BRANCH="${BUILDKITE_BRANCH}"
 export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
+
+# XXX: DO NOT MERGE
+BRANCH="9.2"
 
 # Retrieve version value
 MANIFEST_VERSION=$(curl -s --retry 5 --retry-delay 10 "$MANIFEST_URL" | jq -r '.version')

--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -21,9 +21,6 @@ BRANCH="${BUILDKITE_BRANCH}"
 export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
 
-# XXX: DO NOT MERGE
-BRANCH="9.2"
-
 # Retrieve version value
 MANIFEST_VERSION=$(curl -s --retry 5 --retry-delay 10 "$MANIFEST_URL" | jq -r '.version')
 # remove -SNAPSHOT or -alpha1 style suffix from MANIFEST_VERSION

--- a/.buildkite/scripts/test.ps1
+++ b/.buildkite/scripts/test.ps1
@@ -9,13 +9,13 @@ write-host "`$env:AGENT = $($Env:AGENT)"
 
 if ($psversiontable.psversion -lt "7.4.0") {
     # Download Powershell Core, and rerun this script using Powershell Core
-    
+
     write-host "Downloading Powershell Core"
     invoke-webrequest -uri https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/PowerShell-7.4.0-win-x64.zip -outfile pwsh.zip
-    
+
     write-host "Expanding Powershell Core"
     Expand-Archive pwsh.zip -destinationpath (Join-Path $PSScriptRoot "pwsh")
-    
+
     Write-host "Invoking from Powershell Core"
     & (Join-Path $PSScriptRoot "pwsh/pwsh.exe") -file (Join-Path $PSScriptRoot "test.ps1")
 
@@ -28,7 +28,8 @@ if ($psversiontable.psversion -lt "7.4.0") {
     }
 }
 
-$AgentMSI = Get-ChildItem bin/out -Include "elastic-agent*.msi" -Recurse
+# Default to x86_64 for now until Windows/arm64 testing is added
+$AgentMSI = Get-ChildItem bin/out -Include "elastic-agent*x86_64*.msi" -Recurse
 
 if ($AgentMSI -eq $null) {
     write-error "No agent MSI found to test"

--- a/src/build/BullseyeTargets/FindPackageTarget.cs
+++ b/src/build/BullseyeTargets/FindPackageTarget.cs
@@ -12,7 +12,7 @@ namespace ElastiBuild.BullseyeTargets
 {
     public class FindPackageTarget : BullseyeTargetBase<FindPackageTarget>
     {
-        public static async Task RunAsync(BuildContext ctx, string targetName)
+        public static async Task RunAsync(BuildContext ctx, string targetName, string arch = "x86_64")
         {
             var cmd = ctx.GetCommand();
             bool forceSwitch = (cmd as ISupportForceSwitch)?.ForceSwitch ?? false;
@@ -50,6 +50,9 @@ namespace ElastiBuild.BullseyeTargets
                             return null;
 
                         if (!fi.Name.Contains("-windows", StringComparison.OrdinalIgnoreCase))
+                            return null;
+
+                        if (ap.Architecture != arch)
                             return null;
 
                         return ap;

--- a/src/build/Commands/BuildCommand.cs
+++ b/src/build/Commands/BuildCommand.cs
@@ -18,12 +18,14 @@ namespace ElastiBuild.Commands
         , ISupportRequiredContainerId
         , ISupportCodeSigning
         , ISupportWxsOnlySwitch
+        , ISupportArchitecture
     {
         public IEnumerable<string> Targets { get; set; }
         public string ContainerId { get; set; }
         public string CertFile { get; set; }
         public string CertPass { get; set; }
         public bool WxsOnly { get; set; }
+        public string Architecture { get; set; } = "x86_64";
 
         public async Task RunAsync()
         {
@@ -64,7 +66,7 @@ namespace ElastiBuild.Commands
 
                 bt.Add(
                     FindPackageTarget.NameWith(target),
-                    async () => await FindPackageTarget.RunAsync(ctx, target));
+                    async () => await FindPackageTarget.RunAsync(ctx, target, Architecture));
 
                 bt.Add(
                     FetchPackageTarget.NameWith(target),

--- a/src/build/Commands/FetchCommand.cs
+++ b/src/build/Commands/FetchCommand.cs
@@ -16,11 +16,12 @@ namespace ElastiBuild.Commands
         , ISupportRequiredTargets
         , ISupportRequiredContainerId
         , ISupportForceSwitch
+        , ISupportArchitecture
     {
         public IEnumerable<string> Targets { get; set; }
         public string ContainerId { get; set; }
         public bool ForceSwitch { get; set; }
-
+        public string Architecture { get; set; } = "x86_64";
         public async Task RunAsync()
         {
             if (Targets.Any(t => t.ToLower() == "all"))

--- a/src/build/Features/ISupportArchitecture.cs
+++ b/src/build/Features/ISupportArchitecture.cs
@@ -7,23 +7,13 @@ namespace ElastiBuild.Commands
         public static class ISupportArchitecture
         {
             public static string Architecture =>
-                "Architecture. x86_64 or arm64";
+                "Architecture. x86_64 or arm64. Default is x86_64";
         }
     }
 
     public interface ISupportArchitecture
     {
-        // TODO: arch latest
         [Option("arch", Default = "x86_64", HelpText = nameof(Architecture), ResourceType = typeof(Resources.ISupportArchitecture))]
         string Architecture { get; set; }
     }
-
-/*
-    public interface ISupportRequiredArchitecture
-    {
-        // TODO: arch latest
-        [Option("arch", Required = true, HelpText = nameof(Architecture), ResourceType = typeof(Resources.ISupportArchitecture))]
-        string Architecture { get; set; }
-    }
-*/
 }

--- a/src/build/Features/ISupportArchitecture.cs
+++ b/src/build/Features/ISupportArchitecture.cs
@@ -1,0 +1,29 @@
+using CommandLine;
+
+namespace ElastiBuild.Commands
+{
+    namespace Resources
+    {
+        public static class ISupportArchitecture
+        {
+            public static string Architecture =>
+                "Architecture. x86_64 or arm64";
+        }
+    }
+
+    public interface ISupportArchitecture
+    {
+        // TODO: arch latest
+        [Option("arch", Default = "x86_64", HelpText = nameof(Architecture), ResourceType = typeof(Resources.ISupportArchitecture))]
+        string Architecture { get; set; }
+    }
+
+/*
+    public interface ISupportRequiredArchitecture
+    {
+        // TODO: arch latest
+        [Option("arch", Required = true, HelpText = nameof(Architecture), ResourceType = typeof(Resources.ISupportArchitecture))]
+        string Architecture { get; set; }
+    }
+*/
+}

--- a/src/build/Infra/ArtifactsApi.cs
+++ b/src/build/Infra/ArtifactsApi.cs
@@ -54,7 +54,7 @@ namespace ElastiBuild.Infra
             return namedItems;
         }
 
-        public static async Task<IEnumerable<ArtifactPackage>> DiscoverArtifacts(string target, string containerId)
+        public static async Task<IEnumerable<ArtifactPackage>> DiscoverArtifacts(string target, string containerId, string arch = "x86_64")
         {
             using var http = new HttpClient()
             {
@@ -62,7 +62,7 @@ namespace ElastiBuild.Infra
                 Timeout = TimeSpan.FromMilliseconds(3000)
             };
 
-            var query = $"search/{containerId}/{target},windows,zip,x86_64";
+            var query = $"search/{containerId}/{target},windows,zip,{arch}";
             using var stm = await http.GetStreamAsync(query);
 
             using var sr = new StreamReader(stm);

--- a/src/shared/ArtifactPackage.cs
+++ b/src/shared/ArtifactPackage.cs
@@ -25,7 +25,7 @@ namespace Elastic.Installer
         public bool IsOss { get; private set; }
         public string CanonicalTargetName { get; private set; }
 
-        public bool Is64Bit => Architecture == MagicStrings.Arch.x86_64;
+        public bool Is64Bit => (Architecture == MagicStrings.Arch.x86_64) || (Architecture == MagicStrings.Arch.arm64);
         public bool IsDownloadable => !Url.IsEmpty();
         public bool IsQualified => !Qualifier.IsEmpty();
 

--- a/src/shared/MagicStrings.cs
+++ b/src/shared/MagicStrings.cs
@@ -84,6 +84,7 @@ namespace Elastic.Installer
         public static class Arch
         {
             public static readonly string x86_64 = "x86_64";
+            public static readonly string arm64 = "arm64";
         }
 
         public static class Ver


### PR DESCRIPTION
## Summary
This adds the building of an `arm64` MSI for Elastic Agent.  

## Details
It builds on the same x86_64 machine as the rest of the MSIs.

This only currently adds the `arm64` for Agent and not for any Beats.  Once an MSI is desired for them, it should be a fairly straightforward update to `.buildkite/scripts/build.ps1` to include them.

## Implementation

This adds an `--arch` parameter to the .NET program that builds the MSIs, with a default value of `x86_64`.  This means if someone runs it without this parameter, it will behave just as it did before.

The `.buildkite/scripts/build.ps1` file had logic updates to first build the Windows `arm64` MSI, then build the `x86_64` MSI(s).

This update to run the program twice w/ a new `--arch` parameter was overall simpler to implement; otherwise it seemed a lot more refactoring would have been necessary to be able to handle multiple architectures in one invocation.

## Successful Build
Successful `staging` build that includes both `x86_64` and `arm64` MSI for elastic-agent: https://buildkite.com/elastic/elastic-stack-installers/builds/13855#019a7a2c-6c3c-4ace-b8a5-32270b6a7829

(The Staging DRA upload failure was expected since it was not run from a proper Release branch for DRA Upload to be successful)

## Expected PR Build Failure

The PR build failure here is the same one that has happened in the last few PR builds over the past month, and those PRs were merged.  It doesn't appear that the failure is related to my changes. It looks like some of the testing may need some work outside of this PR.  (One of the tests uses an old `8.11` artifact to test against).

    https://buildkite.com/elastic/elastic-stack-installers/builds/13779#019a4abc-a4d0-4329-b4ed-c99df8ca1d6c
    https://buildkite.com/elastic/elastic-stack-installers/builds/13650#019a0d3c-fa2d-4f82-b657-7d66a80add88
    https://buildkite.com/elastic/elastic-stack-installers/builds/13648#019a0d3f-3dfb-433d-acde-05683b1731a5

## Backport
This will be manually backported only to `9.2` since Agent does not produce Windows/arm64 artifacts in 9.1 and older.


## Related Issue
Related: https://github.com/elastic/endpoint-dev/issues/17666

cc @nfritts @gogochan @cmacknz 