### PR TITLE
[9.2] [Agent] Add ability to build MSI for elastic-agent for arm64 (#343)

### DIFF
--- a/.buildkite/scripts/dra-publish.sh
+++ b/.buildkite/scripts/dra-publish.sh
@@ -11,12 +11,12 @@ buildkite-agent artifact download 'users\buildkite\esi\bin\out\**\*.msi' . --ste
 mv users/buildkite/esi/bin bin
 chmod -R 777 bin/out
 
-echo "+++ Setting DRA params" 
+echo "+++ Setting DRA params"
 # Shared secret path containing the dra creds for project teams
 DRA_CREDS=$(vault kv get -field=data -format=json kv/ci-shared/release/dra-role)
 VAULT_ADDR=$(echo $DRA_CREDS | jq -r '.vault_addr')
 VAULT_ROLE_ID=$(echo $DRA_CREDS | jq -r '.role_id')
-VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id') 
+VAULT_SECRET_ID=$(echo $DRA_CREDS | jq -r '.secret_id')
 BRANCH="${BUILDKITE_BRANCH}"
 export VAULT_ADDR VAULT_ROLE_ID VAULT_SECRET_ID
 VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"

--- a/.buildkite/scripts/test.ps1
+++ b/.buildkite/scripts/test.ps1
@@ -9,13 +9,13 @@ write-host "`$env:AGENT = $($Env:AGENT)"
 
 if ($psversiontable.psversion -lt "7.4.0") {
     # Download Powershell Core, and rerun this script using Powershell Core
-    
+
     write-host "Downloading Powershell Core"
     invoke-webrequest -uri https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/PowerShell-7.4.0-win-x64.zip -outfile pwsh.zip
-    
+
     write-host "Expanding Powershell Core"
     Expand-Archive pwsh.zip -destinationpath (Join-Path $PSScriptRoot "pwsh")
-    
+
     Write-host "Invoking from Powershell Core"
     & (Join-Path $PSScriptRoot "pwsh/pwsh.exe") -file (Join-Path $PSScriptRoot "test.ps1")
 
@@ -28,7 +28,8 @@ if ($psversiontable.psversion -lt "7.4.0") {
     }
 }
 
-$AgentMSI = Get-ChildItem bin/out -Include "elastic-agent*.msi" -Recurse
+# Default to x86_64 for now until Windows/arm64 testing is added
+$AgentMSI = Get-ChildItem bin/out -Include "elastic-agent*x86_64*.msi" -Recurse
 
 if ($AgentMSI -eq $null) {
     write-error "No agent MSI found to test"

--- a/src/build/BullseyeTargets/FindPackageTarget.cs
+++ b/src/build/BullseyeTargets/FindPackageTarget.cs
@@ -12,7 +12,7 @@ namespace ElastiBuild.BullseyeTargets
 {
     public class FindPackageTarget : BullseyeTargetBase<FindPackageTarget>
     {
-        public static async Task RunAsync(BuildContext ctx, string targetName)
+        public static async Task RunAsync(BuildContext ctx, string targetName, string arch = "x86_64")
         {
             var cmd = ctx.GetCommand();
             bool forceSwitch = (cmd as ISupportForceSwitch)?.ForceSwitch ?? false;
@@ -50,6 +50,9 @@ namespace ElastiBuild.BullseyeTargets
                             return null;
 
                         if (!fi.Name.Contains("-windows", StringComparison.OrdinalIgnoreCase))
+                            return null;
+
+                        if (ap.Architecture != arch)
                             return null;
 
                         return ap;

--- a/src/build/Commands/BuildCommand.cs
+++ b/src/build/Commands/BuildCommand.cs
@@ -18,12 +18,14 @@ namespace ElastiBuild.Commands
         , ISupportRequiredContainerId
         , ISupportCodeSigning
         , ISupportWxsOnlySwitch
+        , ISupportArchitecture
     {
         public IEnumerable<string> Targets { get; set; }
         public string ContainerId { get; set; }
         public string CertFile { get; set; }
         public string CertPass { get; set; }
         public bool WxsOnly { get; set; }
+        public string Architecture { get; set; } = "x86_64";
 
         public async Task RunAsync()
         {
@@ -64,7 +66,7 @@ namespace ElastiBuild.Commands
 
                 bt.Add(
                     FindPackageTarget.NameWith(target),
-                    async () => await FindPackageTarget.RunAsync(ctx, target));
+                    async () => await FindPackageTarget.RunAsync(ctx, target, Architecture));
 
                 bt.Add(
                     FetchPackageTarget.NameWith(target),

--- a/src/build/Commands/FetchCommand.cs
+++ b/src/build/Commands/FetchCommand.cs
@@ -16,11 +16,12 @@ namespace ElastiBuild.Commands
         , ISupportRequiredTargets
         , ISupportRequiredContainerId
         , ISupportForceSwitch
+        , ISupportArchitecture
     {
         public IEnumerable<string> Targets { get; set; }
         public string ContainerId { get; set; }
         public bool ForceSwitch { get; set; }
-
+        public string Architecture { get; set; } = "x86_64";
         public async Task RunAsync()
         {
             if (Targets.Any(t => t.ToLower() == "all"))

--- a/src/build/Features/ISupportArchitecture.cs
+++ b/src/build/Features/ISupportArchitecture.cs
@@ -1,0 +1,19 @@
+using CommandLine;
+
+namespace ElastiBuild.Commands
+{
+    namespace Resources
+    {
+        public static class ISupportArchitecture
+        {
+            public static string Architecture =>
+                "Architecture. x86_64 or arm64. Default is x86_64";
+        }
+    }
+
+    public interface ISupportArchitecture
+    {
+        [Option("arch", Default = "x86_64", HelpText = nameof(Architecture), ResourceType = typeof(Resources.ISupportArchitecture))]
+        string Architecture { get; set; }
+    }
+}

--- a/src/build/Infra/ArtifactsApi.cs
+++ b/src/build/Infra/ArtifactsApi.cs
@@ -54,7 +54,7 @@ namespace ElastiBuild.Infra
             return namedItems;
         }
 
-        public static async Task<IEnumerable<ArtifactPackage>> DiscoverArtifacts(string target, string containerId)
+        public static async Task<IEnumerable<ArtifactPackage>> DiscoverArtifacts(string target, string containerId, string arch = "x86_64")
         {
             using var http = new HttpClient()
             {
@@ -62,7 +62,7 @@ namespace ElastiBuild.Infra
                 Timeout = TimeSpan.FromMilliseconds(3000)
             };
 
-            var query = $"search/{containerId}/{target},windows,zip,x86_64";
+            var query = $"search/{containerId}/{target},windows,zip,{arch}";
             using var stm = await http.GetStreamAsync(query);
 
             using var sr = new StreamReader(stm);

--- a/src/shared/ArtifactPackage.cs
+++ b/src/shared/ArtifactPackage.cs
@@ -25,7 +25,7 @@ namespace Elastic.Installer
         public bool IsOss { get; private set; }
         public string CanonicalTargetName { get; private set; }
 
-        public bool Is64Bit => Architecture == MagicStrings.Arch.x86_64;
+        public bool Is64Bit => (Architecture == MagicStrings.Arch.x86_64) || (Architecture == MagicStrings.Arch.arm64);
         public bool IsDownloadable => !Url.IsEmpty();
         public bool IsQualified => !Qualifier.IsEmpty();
 

--- a/src/shared/MagicStrings.cs
+++ b/src/shared/MagicStrings.cs
@@ -84,6 +84,7 @@ namespace Elastic.Installer
         public static class Arch
         {
             public static readonly string x86_64 = "x86_64";
+            public static readonly string arm64 = "arm64";
         }
 
         public static class Ver


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Agent] Add ability to build MSI for elastic-agent for arm64 (#343)](https://github.com/elastic/elastic-stack-installers/pull/343)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)