### PR TITLE
add DRA version bump pipeline

### DIFF
--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -34,7 +34,7 @@ steps:
     key: fetch-dra-artifacts
     depends_on: block-get-dra-artifacts
     agents:
-      image: docker.elastic.co/release-eng/ubuntu-build-essential-release-eng:latest
+      image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
       cpu: 2
       memory: 4G
       ephemeralStorage: 10G

--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -1,0 +1,46 @@
+notify:
+  - slack:
+      channels:
+        - "#test-channel-for-plugin"
+    if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
+  - slack:
+      channels:
+        - "#test-channel-for-plugin"
+      message: "🚦 Pipeline waiting for approval 🚦\n*Ready to fetch DRA artifacts - Please unblock when ready.*"
+    if: build.state == "blocked"
+
+steps:
+  - block: "Ready to fetch for DRA artifacts?"
+    prompt: "Unblock when your team is ready to proceed."
+    key: block-get-dra-artifacts
+    blocked_state: running
+
+  - label: "Fetch DRA Artifacts"
+    key: fetch-dra-artifacts
+    depends_on: block-get-dra-artifacts
+    agents:
+      image: docker.elastic.co/release-eng/ubuntu-build-essential-release-eng:latest
+      cpu: 2
+      memory: 4G
+      ephemeralStorage: 10G
+    command:
+      - echo "Starting DRA artifacts retrieval..."
+    timeout_in_minutes: 240
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
+      manual:
+        permit_on_passed: true
+
+    plugins:
+      - elastic/json-watcher#v1.0.0:
+          url: "${STAGING_URL}"
+          field: "${FIELD}"
+          expected_value: "${EXPECTED_VALUE}"
+          polling_interval: "${POLLING_INTERVAL}"
+      - elastic/json-watcher#v1.0.0:
+          url: "${SNAPSHOT_URL}"
+          field: "${FIELD}"
+          expected_value: "${EXPECTED_VALUE}-SNAPSHOT"
+          polling_interval: "${POLLING_INTERVAL}"

--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -1,17 +1,31 @@
 notify:
   - slack:
       channels:
-        - "#test-channel-for-plugin"
+        - "#ingest-notifications"
     if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
   - slack:
       channels:
-        - "#test-channel-for-plugin"
-      message: "🚦 Pipeline waiting for approval 🚦\n*Ready to fetch DRA artifacts - Please unblock when ready.*"
+        - "#ingest-notifications"
+      message: |
+        🚦 Pipeline waiting for approval 🚦
+        Product: `${PRODUCT}`
+        
+        Ready to fetch DRA artifacts - please unblock when ready.
+        New version: `${NEW_VERSION}`
+        Branch: `${BRANCH}`
+        Workflow: `${WORKFLOW}`
+        ${BUILDKITE_BUILD_URL}
     if: build.state == "blocked"
 
 steps:
   - block: "Ready to fetch for DRA artifacts?"
-    prompt: "Unblock when your team is ready to proceed."
+    prompt: |
+      Unblock when your team is ready to proceed.
+
+      Trigger parameters:
+      - NEW_VERSION: ${NEW_VERSION}
+      - BRANCH: ${BRANCH}
+      - WORKFLOW: ${WORKFLOW}
     key: block-get-dra-artifacts
     blocked_state: running
 
@@ -37,10 +51,10 @@ steps:
       - elastic/json-watcher#v1.0.0:
           url: "${STAGING_URL}"
           field: "${FIELD}"
-          expected_value: "${EXPECTED_VALUE}"
+          expected_value: "${NEW_VERSION}"
           polling_interval: "${POLLING_INTERVAL}"
       - elastic/json-watcher#v1.0.0:
           url: "${SNAPSHOT_URL}"
           field: "${FIELD}"
-          expected_value: "${EXPECTED_VALUE}-SNAPSHOT"
+          expected_value: "${NEW_VERSION}-SNAPSHOT"
           polling_interval: "${POLLING_INTERVAL}"

--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -35,9 +35,9 @@ steps:
     depends_on: block-get-dra-artifacts
     agents:
       image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
-      cpu: 2
-      memory: 4G
-      ephemeralStorage: 10G
+      cpu: 250m
+      memory: 512Mi
+      ephemeralStorage: 1Gi
     command:
       - echo "Starting DRA artifacts retrieval..."
     timeout_in_minutes: 240

--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -8,8 +8,8 @@ notify:
         - "#ingest-notifications"
       message: |
         🚦 Pipeline waiting for approval 🚦
-        Product: `${PRODUCT}`
-        
+        Repo: `${REPO}`
+
         Ready to fetch DRA artifacts - please unblock when ready.
         New version: `${NEW_VERSION}`
         Branch: `${BRANCH}`
@@ -18,6 +18,7 @@ notify:
     if: build.state == "blocked"
 
 steps:
+  # TODO: replace this block step by real version bump logic
   - block: "Ready to fetch for DRA artifacts?"
     prompt: |
       Unblock when your team is ready to proceed.
@@ -49,12 +50,12 @@ steps:
 
     plugins:
       - elastic/json-watcher#v1.0.0:
-          url: "${STAGING_URL}"
-          field: "${FIELD}"
+          url: "https://artifacts-staging.elastic.co/elastic-stack-installers/latest/${BRANCH}.json"
+          field: ".version"
           expected_value: "${NEW_VERSION}"
-          polling_interval: "${POLLING_INTERVAL}"
+          polling_interval: "30"
       - elastic/json-watcher#v1.0.0:
-          url: "${SNAPSHOT_URL}"
-          field: "${FIELD}"
+          url: "https://storage.googleapis.com/elastic-artifacts-snapshot/elastic-stack-installers/latest/${BRANCH}.json"
+          field: ".version"
           expected_value: "${NEW_VERSION}-SNAPSHOT"
-          polling_interval: "${POLLING_INTERVAL}"
+          polling_interval: "30"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -129,8 +129,6 @@ spec:
     spec:
       pipeline_file: ".buildkite/version-bump-pipeline.yml"
       provider_settings:
-        build_branches: false
-        build_pull_requests: false
         trigger_mode: none
       repository: elastic/elastic-stack-installers
       teams:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -104,3 +104,38 @@ spec:
         ingest-fp: {}
         release-eng: {}
         observablt-robots: {}
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-stack-installers-version-bump
+  description: Buildkite Pipeline for elastic-stack-installers version bump
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-stack-installers-version-bump
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Buildkite Pipeline for elastic-stack-installers version bump
+      name: elastic-stack-installers-version-bump
+    spec:
+      pipeline_file: ".buildkite/version-bump-pipeline.yml"
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        trigger_mode: none
+      repository: elastic/elastic-stack-installers
+      teams:
+        everyone:
+          access_level: BUILD_AND_READ
+        ingest-fp: {}
+        release-eng: {}
+        observablt-robots: {}


### PR DESCRIPTION
## Description
Hi Team,

This PR is the first phase of the version-bump automation rollout as mentioned in [#mission-control](https://elastic.slack.com/archives/C0JFN9HJL/p1770388488482519). It introduces a generalized Buildkite pipeline for service teams in the DRA process. The baseline pipeline includes a block step that waits for each team to unblock before polling for DRA artifacts using a buildkite plugin [json-watcher-buildkite-plugin](https://github.com/elastic/json-watcher-buildkite-plugin) for the polling.

## Related Issue
- https://github.com/elastic/observability-robots/issues/3404
- ~~If you haven't already, please provide the Slack channel name for notifications via a comment here or on the issue listed above~~