### PR TITLE
ci(ff): support feature freeze automation

### DIFF
--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -18,7 +18,16 @@ notify:
     if: build.state == "blocked"
 
 steps:
-  # TODO: replace this block step by real version bump logic
+  - label: "Bump version minor"
+    # NOTE: a new minor is X.Y.0, so we check if the version ends with 0
+    #       to decide if it's a minor or patch release
+    if: build.env("NEW_VERSION") !~ /0$/
+    command: "make release-major-minor CURRENT_RELEASE=${NEW_VERSION}"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
+    agents:
+      image: "docker.elastic.co/ci-agent-images/observability-robots/ubuntu-build-essential:latest"
+
   - block: "Ready to fetch for DRA artifacts?"
     prompt: |
       Unblock when your team is ready to proceed.

--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -19,17 +19,6 @@ notify:
     if: build.state == "blocked"
 
 steps:
-  - block: "Placeholder blocked step"
-    prompt: |
-      Unblock when your team is ready to proceed.
-
-      Trigger parameters:
-      - NEW_VERSION: ${NEW_VERSION}
-      - BRANCH: ${BRANCH}
-      - WORKFLOW: ${WORKFLOW}
-    key: block-get-dra-artifacts
-    blocked_state: running
-
   - label: "Create branch for version bump"
     if: build.env("WORKFLOW") == "minor"
     command: "make release-major-minor CURRENT_RELEASE=${NEW_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+# Makefile for elastic-stack-installers release automation
+
+# Configuration
+PROJECT_OWNER ?= elastic
+PROJECT_REPO ?= elastic-stack-installers
+BASE_BRANCH ?= main
+
+# Parse version from CURRENT_RELEASE (e.g., 9.5.0 -> 9.5)
+RELEASE_BRANCH ?= $(shell echo $(CURRENT_RELEASE) | sed -E 's/^([0-9]+\.[0-9]+)\.[0-9]+$$/\1/')
+PROJECT_MAJOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -d. -f1)
+
+# DRY_RUN mode - set to "true" to preview commands without executing
+DRY_RUN ?= false
+GIT := $(if $(filter true,$(DRY_RUN)),@echo "[DRY_RUN] git",@git)
+
+# Colors for output
+GREEN := \033[0;32m
+RED := \033[0;31m
+YELLOW := \033[0;33m
+NC := \033[0m # No Color
+
+.PHONY: help
+help:
+	@echo "elastic-stack-installers release automation"
+	@echo ""
+	@echo "Targets:"
+	@echo "  check-requirements    - Validate release requirements"
+	@echo "  create-release-branch - Create and push release branch"
+	@echo "  release-major-minor   - Complete major/minor release workflow"
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  CURRENT_RELEASE       - Version to release (e.g., 9.5.0)"
+	@echo "  BASE_BRANCH           - Base branch (default: main)"
+	@echo "  DRY_RUN              - Set to 'true' for dry-run mode (default: false)"
+	@echo ""
+	@echo "Example usage:"
+	@echo "  make release-major-minor CURRENT_RELEASE=9.5.0"
+	@echo "  DRY_RUN=true make release-major-minor CURRENT_RELEASE=9.5.0"
+	@echo "  make release-major-minor CURRENT_RELEASE=9.5.0 BASE_BRANCH=main"
+
+.PHONY: check-requirements
+check-requirements:
+	@echo "Checking release requirements..."
+	@if [ -z "$(CURRENT_RELEASE)" ]; then \
+		echo "$(RED)Error: CURRENT_RELEASE not set$(NC)"; \
+		echo "$(YELLOW)Usage: make release-major-minor CURRENT_RELEASE=9.5.0$(NC)"; \
+		exit 1; \
+	fi
+	@if [ "$(PROJECT_MAJOR_VERSION)" = "8" ]; then \
+		echo "$(RED)Error: 8.x releases are not supported anymore$(NC)"; \
+		exit 1; \
+	fi
+	@echo "$(GREEN)✓ Requirements check passed$(NC)"
+
+.PHONY: create-release-branch
+create-release-branch: check-requirements
+	@echo "Creating release branch $(RELEASE_BRANCH) from $(BASE_BRANCH)..."
+	$(GIT) checkout $(BASE_BRANCH)
+	$(GIT) pull origin $(BASE_BRANCH)
+	$(GIT) checkout -b $(RELEASE_BRANCH)
+	@if [ "$(DRY_RUN)" = "true" ]; then \
+		echo "[DRY_RUN] git push origin $(RELEASE_BRANCH)"; \
+		echo "$(YELLOW)⚠ DRY_RUN mode: Branch created locally but NOT pushed to remote$(NC)"; \
+	else \
+		git push origin $(RELEASE_BRANCH); \
+		echo "$(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
+	fi
+	@echo ""
+	@echo "Next steps:"
+	@echo "1. Create branch protection rules at:"
+	@echo "   https://github.com/$(PROJECT_OWNER)/$(PROJECT_REPO)/settings/branch_protection_rules/new"
+	@echo "2. Notify release team in #mission-control"
+
+.PHONY: release-major-minor
+release-major-minor: create-release-branch
+	@echo "$(GREEN)✓ Major/minor release branch created successfully$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PROJECT_MAJOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -d. -f1)
 
 # DRY_RUN mode - set to "true" to preview commands without executing
 DRY_RUN ?= false
-GIT := $(if $(filter true,$(DRY_RUN)),@echo "[DRY_RUN] git",@git)
+GIT := $(if $(filter true,$(DRY_RUN)),@echo "[DRY_RUN] git", git)
 
 # Colors for output
 GREEN := \033[0;32m
@@ -31,7 +31,7 @@ help:
 	@echo "Environment variables:"
 	@echo "  CURRENT_RELEASE       - Version to release (e.g., 9.5.0)"
 	@echo "  BASE_BRANCH           - Base branch (default: main)"
-	@echo "  DRY_RUN              - Set to 'true' for dry-run mode (default: false)"
+	@echo "  DRY_RUN               - Set to 'true' for dry-run mode (default: false)"
 	@echo ""
 	@echo "Example usage:"
 	@echo "  make release-major-minor CURRENT_RELEASE=9.5.0"
@@ -50,7 +50,7 @@ check-requirements:
 		echo "$(RED)Error: 8.x releases are not supported anymore$(NC)"; \
 		exit 1; \
 	fi
-	@echo "$(GREEN)✓ Requirements check passed$(NC)"
+	@echo "  $(GREEN)✓ Requirements check passed$(NC)"
 
 .PHONY: prepare-base-branch
 prepare-base-branch:
@@ -62,19 +62,19 @@ prepare-base-branch:
 create-release-branch: check-requirements prepare-base-branch
 	@if $(GIT) ls-remote --heads origin $(RELEASE_BRANCH) | grep -q .; then \
 		echo "$(YELLOW)⚠ Branch $(RELEASE_BRANCH) already exists on remote, skipping$(NC)"; \
-	elif [ "$(DRY_RUN)" = "true" ]; then \
-		echo "[DRY_RUN] git checkout -b $(RELEASE_BRANCH)"; \
-		echo "[DRY_RUN] git push origin $(RELEASE_BRANCH)"; \
-		echo "$(YELLOW)⚠ DRY_RUN mode: Branch created locally but NOT pushed to remote$(NC)"; \
 	else \
 		$(GIT) checkout -b $(RELEASE_BRANCH); \
 		$(GIT) push origin $(RELEASE_BRANCH); \
-		echo "$(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
+		if [ "$(DRY_RUN)" = "true" ]; then \
+			echo "$(YELLOW)⚠ DRY_RUN mode: Branch created locally but NOT pushed to remote$(NC)"; \
+		else \
+			echo "$(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
+		fi; \
 	fi
 
 .PHONY: release-major-minor
 release-major-minor: create-release-branch
-	@echo "$(GREEN)✓ Major/minor release branch created successfully$(NC)"
+	@echo "  $(GREEN)✓ Major/minor release branch created successfully$(NC)"
 	@echo ""
 	@echo "Next steps:"
 	@echo "1. Create branch protection rules at:"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ RELEASE_BRANCH ?= $(shell echo $(CURRENT_RELEASE) | sed -E 's/^([0-9]+\.[0-9]+)\
 PROJECT_MAJOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -d. -f1)
 
 # DRY_RUN mode - set to "true" to preview commands without executing
-DRY_RUN ?= false
 GIT := git
 
 # Colors for output

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,14 @@ check-requirements:
 	fi
 	@echo "$(GREEN)✓ Requirements check passed$(NC)"
 
-.PHONY: create-release-branch
-create-release-branch: check-requirements
+.PHONY: prepare-base-branch
+prepare-base-branch:
 	@echo "Creating release branch $(RELEASE_BRANCH) from $(BASE_BRANCH)..."
 	$(GIT) checkout $(BASE_BRANCH)
 	$(GIT) pull origin $(BASE_BRANCH)
+
+.PHONY: create-release-branch
+create-release-branch: check-requirements prepare-base-branch
 	@if $(GIT) ls-remote --heads origin $(RELEASE_BRANCH) | grep -q .; then \
 		echo "$(YELLOW)⚠ Branch $(RELEASE_BRANCH) already exists on remote, skipping$(NC)"; \
 	elif [ "$(DRY_RUN)" = "true" ]; then \
@@ -68,12 +71,12 @@ create-release-branch: check-requirements
 		$(GIT) push origin $(RELEASE_BRANCH); \
 		echo "$(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
 	fi
+
+.PHONY: release-major-minor
+release-major-minor: create-release-branch
+	@echo "$(GREEN)✓ Major/minor release branch created successfully$(NC)"
 	@echo ""
 	@echo "Next steps:"
 	@echo "1. Create branch protection rules at:"
 	@echo "   https://github.com/$(PROJECT_OWNER)/$(PROJECT_REPO)/settings/branch_protection_rules/new"
 	@echo "2. Notify release team in #mission-control"
-
-.PHONY: release-major-minor
-release-major-minor: create-release-branch
-	@echo "$(GREEN)✓ Major/minor release branch created successfully$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PROJECT_MAJOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -d. -f1)
 
 # DRY_RUN mode - set to "true" to preview commands without executing
 DRY_RUN ?= false
-GIT := $(if $(filter true,$(DRY_RUN)),@echo "[DRY_RUN] git", git)
+GIT := git
 
 # Colors for output
 GREEN := \033[0;32m
@@ -35,7 +35,6 @@ help:
 	@echo ""
 	@echo "Example usage:"
 	@echo "  make release-major-minor CURRENT_RELEASE=9.5.0"
-	@echo "  DRY_RUN=true make release-major-minor CURRENT_RELEASE=9.5.0"
 	@echo "  make release-major-minor CURRENT_RELEASE=9.5.0 BASE_BRANCH=main"
 
 .PHONY: check-requirements
@@ -55,28 +54,19 @@ check-requirements:
 .PHONY: prepare-base-branch
 prepare-base-branch:
 	@echo "Creating release branch $(RELEASE_BRANCH) from $(BASE_BRANCH)..."
-	$(GIT) checkout $(BASE_BRANCH)
-	$(GIT) pull origin $(BASE_BRANCH)
+	$(GIT) checkout --quiet $(BASE_BRANCH)
+	$(GIT) pull --quiet origin $(BASE_BRANCH)
 
 .PHONY: create-release-branch
 create-release-branch: check-requirements prepare-base-branch
 	@if $(GIT) ls-remote --heads origin $(RELEASE_BRANCH) | grep -q .; then \
 		echo "$(YELLOW)⚠ Branch $(RELEASE_BRANCH) already exists on remote, skipping$(NC)"; \
 	else \
-		$(GIT) checkout -b $(RELEASE_BRANCH); \
-		$(GIT) push origin $(RELEASE_BRANCH); \
-		if [ "$(DRY_RUN)" = "true" ]; then \
-			echo "$(YELLOW)⚠ DRY_RUN mode: Branch created locally but NOT pushed to remote$(NC)"; \
-		else \
-			echo "$(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
-		fi; \
+		$(GIT) checkout --quiet -b $(RELEASE_BRANCH); \
+		$(GIT) push --quiet origin $(RELEASE_BRANCH); \
+		echo "  $(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
+		echo "$(GREEN)✓ Major/minor release branch created successfully$(NC)"; \
 	fi
 
 .PHONY: release-major-minor
 release-major-minor: create-release-branch
-	@echo "  $(GREEN)✓ Major/minor release branch created successfully$(NC)"
-	@echo ""
-	@echo "Next steps:"
-	@echo "1. Create branch protection rules at:"
-	@echo "   https://github.com/$(PROJECT_OWNER)/$(PROJECT_REPO)/settings/branch_protection_rules/new"
-	@echo "2. Notify release team in #mission-control"

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,14 @@ create-release-branch: check-requirements
 	@echo "Creating release branch $(RELEASE_BRANCH) from $(BASE_BRANCH)..."
 	$(GIT) checkout $(BASE_BRANCH)
 	$(GIT) pull origin $(BASE_BRANCH)
-	$(GIT) checkout -b $(RELEASE_BRANCH)
-	@if [ "$(DRY_RUN)" = "true" ]; then \
+	@if $(GIT) ls-remote --heads origin $(RELEASE_BRANCH) | grep -q .; then \
+		echo "$(YELLOW)⚠ Branch $(RELEASE_BRANCH) already exists on remote, skipping$(NC)"; \
+	elif [ "$(DRY_RUN)" = "true" ]; then \
+		echo "[DRY_RUN] git checkout -b $(RELEASE_BRANCH)"; \
 		echo "[DRY_RUN] git push origin $(RELEASE_BRANCH)"; \
 		echo "$(YELLOW)⚠ DRY_RUN mode: Branch created locally but NOT pushed to remote$(NC)"; \
 	else \
+		$(GIT) checkout -b $(RELEASE_BRANCH); \
 		$(GIT) push origin $(RELEASE_BRANCH); \
 		echo "$(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ create-release-branch: check-requirements
 		echo "[DRY_RUN] git push origin $(RELEASE_BRANCH)"; \
 		echo "$(YELLOW)⚠ DRY_RUN mode: Branch created locally but NOT pushed to remote$(NC)"; \
 	else \
-		git push origin $(RELEASE_BRANCH); \
+		$(GIT) push origin $(RELEASE_BRANCH); \
 		echo "$(GREEN)✓ Created and pushed branch $(RELEASE_BRANCH)$(NC)"; \
 	fi
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ See [ElastiBuild](https://github.com/elastic/elastic-stack-installers/wiki/Elast
 **NOTE**: *Building from source should only be done for development purposes. Only the officially distributed and signed Elastic Stack Installers should be used in production. Using unofficial Elastic Stack Installers is not supported.*
 
 ---
+
+## Release Process
+
+This repository uses a simple Makefile for release automation. To create a new release:
+
+```bash
+make release-major-minor CURRENT_RELEASE=9.5.0
+```
+
+For detailed release documentation, including DRY_RUN mode and troubleshooting, see [RELEASE.md](./RELEASE.md).
+
+---
 ## Installing to a custom location
 The default target folder for the MSI is typically something like `c:\Program Files\Elastic\Beats\<version>\<beat>` eg. `c:\Program Files\Elastic\Beats\8.12.0\winlogbeat`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,188 @@
+# Release Guide for elastic-stack-installers
+
+This repository uses a Makefile for minimal release automation. Unlike other Elastic projects, elastic-stack-installers does NOT have version files to update - releases only require creating a release branch.
+
+## Quick Start
+
+### Major/Minor Release (e.g., 9.5.0)
+
+```bash
+# Create and push release branch
+make release-major-minor CURRENT_RELEASE=9.5.0
+```
+
+This will:
+1. Validate release requirements (blocks 8.x minor releases)
+2. Checkout and pull the latest from the base branch
+3. Create release branch (e.g., `9.5` from `9.5.0`)
+4. Push the branch to origin
+
+After running the command, you'll need to manually:
+1. Create branch protection rules on GitHub
+2. Notify the release team in #mission-control
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CURRENT_RELEASE` | Yes | - | Version to release (e.g., 9.5.0) |
+| `BASE_BRANCH` | No | `main` | Base branch to create release from |
+| `PROJECT_OWNER` | No | `elastic` | GitHub organization/owner |
+| `PROJECT_REPO` | No | `elastic-stack-installers` | Repository name |
+| `DRY_RUN` | No | `false` | Set to `true` for dry-run mode |
+
+## Available Targets
+
+### `make help`
+Display usage information and available targets.
+
+```bash
+make help
+```
+
+### `make check-requirements`
+Validate release requirements without creating a branch.
+
+```bash
+make check-requirements CURRENT_RELEASE=9.5.0
+```
+
+This checks:
+- CURRENT_RELEASE is set
+- 8.x releases are blocked (deprecated)
+
+### `make create-release-branch`
+Create and push the release branch.
+
+```bash
+make create-release-branch CURRENT_RELEASE=9.5.0
+```
+
+### `make release-major-minor`
+Complete major/minor release workflow (runs all the above).
+
+```bash
+make release-major-minor CURRENT_RELEASE=9.5.0
+```
+
+## DRY_RUN Mode
+
+Test the release workflow without making changes:
+
+```bash
+# Preview what would happen
+DRY_RUN=true make release-major-minor CURRENT_RELEASE=9.5.0
+
+# Review the dry-run output
+# If everything looks good, run for real:
+make release-major-minor CURRENT_RELEASE=9.5.0
+```
+
+## Testing on Your Fork
+
+To test the release automation on your fork:
+
+```bash
+# Fork the repository first, then:
+cd elastic-stack-installers
+
+# Test with dry-run first
+DRY_RUN=true make release-major-minor \
+  CURRENT_RELEASE=9.5.0-test \
+  PROJECT_OWNER=your-username
+
+# If dry-run looks good, test for real
+make release-major-minor \
+  CURRENT_RELEASE=9.5.0-test \
+  PROJECT_OWNER=your-username
+```
+
+## What This Project Does NOT Do
+
+Unlike other Elastic projects (beats, elastic-agent, etc.), elastic-stack-installers:
+
+- **Does NOT update version files** - No version.go, version.yml, or similar files exist
+- **Does NOT update documentation** - No version-specific documentation to update
+- **Does NOT create pull requests** - Release branch creation is manual
+- **Does NOT have patch releases** - Only major/minor releases
+
+Versioning is managed externally via Git tags only.
+
+## Prerequisites
+
+Standard Unix tools (already installed on most systems):
+- `git` - For branch operations
+- `make` - For running the Makefile
+
+**No special tools required** - no hub CLI, gh CLI, Python, or Go dependencies.
+
+## Branch Naming
+
+Release branches are automatically named based on `CURRENT_RELEASE`:
+
+| CURRENT_RELEASE | Release Branch |
+|----------------|----------------|
+| 9.5.0 | 9.5 |
+| 10.0.0 | 10.0 |
+| 8.19.0 | 8.19 |
+
+The branch name is automatically parsed from the major.minor portion of the version.
+
+## Post-Release Steps
+
+After creating the release branch:
+
+1. **Branch Protection**: Create branch protection rules at:
+   ```
+   https://github.com/elastic/elastic-stack-installers/settings/branch_protection_rules/new
+   ```
+
+2. **Notification**: Notify the release team in the #mission-control Slack channel
+
+3. **Tagging**: Create release tags as needed (manual process)
+
+## Troubleshooting
+
+### Error: CURRENT_RELEASE not set
+Make sure to provide the CURRENT_RELEASE variable:
+```bash
+make release-major-minor CURRENT_RELEASE=9.5.0
+```
+
+### Error: 8.x minor releases are not supported anymore
+8.x minor releases have reached end-of-life. Only 9.x and later are supported.
+
+### Branch already exists
+If the release branch already exists:
+```bash
+# Check existing branches
+git branch -a | grep "9.5"
+
+# Delete local branch if needed
+git branch -D 9.5
+
+# Delete remote branch if needed (use with caution!)
+git push origin --delete 9.5
+```
+
+### Permission denied when pushing
+Make sure you have write access to the repository:
+```bash
+# Check your remote
+git remote -v
+
+# Verify you're authenticated
+git ls-remote origin
+```
+
+## Getting Help
+
+For issues with the release automation:
+1. Check this RELEASE.md guide
+2. Run `make help` for quick reference
+3. Check the Makefile source for implementation details
+4. Ask in #ingest-dev or #mission-control Slack channels
+
+## References
+
+- [Makefile](./Makefile) - Source code for release automation

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,6 @@ After running the command, you'll need to manually:
 | `BASE_BRANCH` | No | `main` | Base branch to create release from |
 | `PROJECT_OWNER` | No | `elastic` | GitHub organization/owner |
 | `PROJECT_REPO` | No | `elastic-stack-installers` | Repository name |
-| `DRY_RUN` | No | `false` | Set to `true` for dry-run mode |
 
 ## Available Targets
 
@@ -65,19 +64,6 @@ Complete major/minor release workflow (runs all the above).
 make release-major-minor CURRENT_RELEASE=9.5.0
 ```
 
-## DRY_RUN Mode
-
-Test the release workflow without making changes:
-
-```bash
-# Preview what would happen
-DRY_RUN=true make release-major-minor CURRENT_RELEASE=9.5.0
-
-# Review the dry-run output
-# If everything looks good, run for real:
-make release-major-minor CURRENT_RELEASE=9.5.0
-```
-
 ## Testing on Your Fork
 
 To test the release automation on your fork:
@@ -85,11 +71,6 @@ To test the release automation on your fork:
 ```bash
 # Fork the repository first, then:
 cd elastic-stack-installers
-
-# Test with dry-run first
-DRY_RUN=true make release-major-minor \
-  CURRENT_RELEASE=9.5.0-test \
-  PROJECT_OWNER=your-username
 
 # If dry-run looks good, test for real
 make release-major-minor \


### PR DESCRIPTION
This should help with creating the release branch automatically.


## Tests

```bash
$ make release-major-minor \
  CURRENT_RELEASE=9.8.0-test \
  PROJECT_OWNER=v1v BASE_BRANCH=feature/release-scripts-for-ff
Checking release requirements...
  ✓ Requirements check passed 
Creating release branch 9.8.0-test from feature/release-scripts-for-ff...
git checkout --quiet feature/release-scripts-for-ff
git pull --quiet origin feature/release-scripts-for-ff
remote: 
remote: Create a pull request for '9.8.0-test' on GitHub by visiting:
remote:      https://github.com/v1v/elastic-stack-installers/pull/new/9.8.0-test
remote: 
  ✓ Created and pushed branch 9.8.0-test 
✓ Major/minor release branch created successfully 
```

```bash
$ make release-major-minor \
  CURRENT_RELEASE=9.8.0-test \
  PROJECT_OWNER=v1v BASE_BRANCH=feature/release-scripts-for-ff
Checking release requirements...
  ✓ Requirements check passed 
Creating release branch 9.8.0-test from feature/release-scripts-for-ff...
git checkout --quiet feature/release-scripts-for-ff
git pull --quiet origin feature/release-scripts-for-ff
⚠ Branch 9.8.0-test already exists on remote, skipping
```

https://github.com/v1v/elastic-stack-installers/tree/9.8.0-test