### PR TITLE
update pipeline setting for version bump

### DIFF
--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -7,10 +7,9 @@ notify:
       channels:
         - "#ingest-notifications"
       message: |
-        🚦 Pipeline waiting for approval 🚦
+        🚦 Pipeline waiting to be unblocked 🚦
         Repo: `${REPO}`
 
-        Ready to fetch DRA artifacts - please unblock when ready.
         New version: `${NEW_VERSION}`
         Branch: `${BRANCH}`
         Workflow: `${WORKFLOW}`
@@ -18,8 +17,8 @@ notify:
     if: build.state == "blocked"
 
 steps:
-  # TODO: replace this block step by real version bump logic
-  - block: "Ready to fetch for DRA artifacts?"
+  # TODO: replace steps with branch creation logic
+  - block: "Placeholder blocked step"
     prompt: |
       Unblock when your team is ready to proceed.
 
@@ -30,8 +29,8 @@ steps:
     key: block-get-dra-artifacts
     blocked_state: running
 
-  - label: "Fetch DRA Artifacts"
-    key: fetch-dra-artifacts
+  - label: "Create branch for version bump"
+    key: branch-for-version-bump
     depends_on: block-get-dra-artifacts
     agents:
       image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
@@ -39,23 +38,4 @@ steps:
       memory: 512Mi
       ephemeralStorage: 1Gi
     command:
-      - echo "Starting DRA artifacts retrieval..."
-    timeout_in_minutes: 240
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 2
-      manual:
-        permit_on_passed: true
-
-    plugins:
-      - elastic/json-watcher#v1.0.0:
-          url: "https://artifacts-staging.elastic.co/elastic-stack-installers/latest/${BRANCH}.json"
-          field: ".version"
-          expected_value: "${NEW_VERSION}"
-          polling_interval: "30"
-      - elastic/json-watcher#v1.0.0:
-          url: "https://storage.googleapis.com/elastic-artifacts-snapshot/elastic-stack-installers/latest/${BRANCH}.json"
-          field: ".version"
-          expected_value: "${NEW_VERSION}-SNAPSHOT"
-          polling_interval: "30"
+      - echo "Placeholder"

--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -7,9 +7,10 @@ notify:
       channels:
         - "#ingest-notifications"
       message: |
-        🚦 Nothing to do here 🚦
+        🚦 Pipeline waiting for approval 🚦
         Repo: `${REPO}`
 
+        Ready to fetch DRA artifacts - please unblock when ready.
         New version: `${NEW_VERSION}`
         Branch: `${BRANCH}`
         Workflow: `${WORKFLOW}`
@@ -17,12 +18,44 @@ notify:
     if: build.state == "blocked"
 
 steps:
-  - label: "Nothing to do here"
-    key: nothing-to-do-here
+  # TODO: replace this block step by real version bump logic
+  - block: "Ready to fetch for DRA artifacts?"
+    prompt: |
+      Unblock when your team is ready to proceed.
+
+      Trigger parameters:
+      - NEW_VERSION: ${NEW_VERSION}
+      - BRANCH: ${BRANCH}
+      - WORKFLOW: ${WORKFLOW}
+    key: block-get-dra-artifacts
+    blocked_state: running
+
+  - label: "Fetch DRA Artifacts"
+    key: fetch-dra-artifacts
+    depends_on: block-get-dra-artifacts
     agents:
       image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
       cpu: 250m
       memory: 512Mi
-      ephemeralStorage: 250m
+      ephemeralStorage: 1Gi
     command:
-      - echo "No DRA to version bump for elastic-stack-installer"
+      - echo "Starting DRA artifacts retrieval..."
+    timeout_in_minutes: 240
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
+      manual:
+        permit_on_passed: true
+
+    plugins:
+      - elastic/json-watcher#v1.0.0:
+          url: "https://artifacts-staging.elastic.co/elastic-stack-installers/latest/${BRANCH}.json"
+          field: ".version"
+          expected_value: "${NEW_VERSION}"
+          polling_interval: "30"
+      - elastic/json-watcher#v1.0.0:
+          url: "https://storage.googleapis.com/elastic-artifacts-snapshot/elastic-stack-installers/latest/${BRANCH}.json"
+          field: ".version"
+          expected_value: "${NEW_VERSION}-SNAPSHOT"
+          polling_interval: "30"

--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -7,10 +7,9 @@ notify:
       channels:
         - "#ingest-notifications"
       message: |
-        🚦 Pipeline waiting for approval 🚦
+        🚦 Nothing to do here 🚦
         Repo: `${REPO}`
 
-        Ready to fetch DRA artifacts - please unblock when ready.
         New version: `${NEW_VERSION}`
         Branch: `${BRANCH}`
         Workflow: `${WORKFLOW}`
@@ -18,44 +17,12 @@ notify:
     if: build.state == "blocked"
 
 steps:
-  # TODO: replace this block step by real version bump logic
-  - block: "Ready to fetch for DRA artifacts?"
-    prompt: |
-      Unblock when your team is ready to proceed.
-
-      Trigger parameters:
-      - NEW_VERSION: ${NEW_VERSION}
-      - BRANCH: ${BRANCH}
-      - WORKFLOW: ${WORKFLOW}
-    key: block-get-dra-artifacts
-    blocked_state: running
-
-  - label: "Fetch DRA Artifacts"
-    key: fetch-dra-artifacts
-    depends_on: block-get-dra-artifacts
+  - label: "Nothing to do here"
+    key: nothing-to-do-here
     agents:
       image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
       cpu: 250m
       memory: 512Mi
-      ephemeralStorage: 1Gi
+      ephemeralStorage: 250m
     command:
-      - echo "Starting DRA artifacts retrieval..."
-    timeout_in_minutes: 240
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 2
-      manual:
-        permit_on_passed: true
-
-    plugins:
-      - elastic/json-watcher#v1.0.0:
-          url: "https://artifacts-staging.elastic.co/elastic-stack-installers/latest/${BRANCH}.json"
-          field: ".version"
-          expected_value: "${NEW_VERSION}"
-          polling_interval: "30"
-      - elastic/json-watcher#v1.0.0:
-          url: "https://storage.googleapis.com/elastic-artifacts-snapshot/elastic-stack-installers/latest/${BRANCH}.json"
-          field: ".version"
-          expected_value: "${NEW_VERSION}-SNAPSHOT"
-          polling_interval: "30"
+      - echo "No DRA to version bump for elastic-stack-installer"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -128,6 +128,7 @@ spec:
       name: elastic-stack-installers-version-bump
     spec:
       pipeline_file: ".buildkite/version-bump-pipeline.yml"
+      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
       repository: elastic/elastic-stack-installers


### PR DESCRIPTION
Hi Team,

This is a followup PR to: https://github.com/elastic/elastic-stack-installers/pull/346

By default `skip_intermediate_builds` is true. In an event that there are parallel version bumps, it would cancel the queued builds in the version bump pipeline.

This PR disables skipping intermediate builds.

See: https://docs.elastic.dev/ci/getting-started-with-buildkite-at-elastic#2-adjust-your-pipeline-settings


---

Additional changes to this version bump pipeline. 

As mentioned in [comment](https://github.com/elastic/elastic-stack-installers/pull/346#issuecomment-3960360003). No version bumps are needed for this pipeline. I've removed the buildkite plugin that polls for the DRA