### PR TITLE
feature(agent): skip MSI uninstall registry entry in favor of agent-managed key

### DIFF
--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -8,7 +8,7 @@ Function Get-LogDir {
     return $Script:LogDir
 }
 
-Function Get-AgentUninstallRegistryKey {
+Function Get-AgentMSIUninstallRegistryKey {
     param (
         [switch] $Passthru
     )
@@ -23,14 +23,19 @@ Function Get-AgentUninstallRegistryKey {
     return $Result.Name
 }
 
-Function Get-AgentUninstallGUID {
-    $RegistryKey = Get-AgentUninstallRegistryKey -Passthru
+Function Get-AgentManagedUninstallRegistryKey {
+    param (
+        [switch] $Passthru
+    )
 
-    try {
-        $GUID = $RegistryKey.PSChildName
-        return $GUID
-    }
-    catch {}
+    $KeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Elastic Agent"
+    if (-not (Test-Path $KeyPath)) { return; }
+
+    $Result = Get-Item $KeyPath
+
+    if ($Passthru) { return $Result }
+
+    return $Result.Name
 }
 
 Function Run-AgentChecks {
@@ -253,9 +258,17 @@ Function Is-AgentFleetEnrolled {
     return $false
 }
 
-Function Is-AgentUninstallKeyPresent {
+Function Is-AgentMSIUninstallKeyPresent {
+    $RegistryKey = @(Get-AgentMSIUninstallRegistryKey)
+    if ($RegistryKey.length -ne 0) {
+        return $true
+    }
 
-    $RegistryKey = @(Get-AgentUninstallRegistryKey)
+    Return $false
+}
+
+Function Is-AgentManagedUninstallKeyPresent {
+    $RegistryKey = @(Get-AgentManagedUninstallRegistryKey)
     if ($RegistryKey.length -ne 0) {
         return $true
     }
@@ -312,10 +325,15 @@ Function Get-AgentLogFile {
 
 
 Function Clean-ElasticAgent {
+    param (
+        [string] $MSIPath
+    )
 
-    try { Clean-ElasticAgentInstaller } catch { }
+    if ($MSIPath) {
+        try { Clean-ElasticAgentInstaller -Path $MSIPath } catch { }
+    }
 
-    Clean-ElasticAgentUninstallKeys
+    Clean-ElasticAgentManagedUninstallKey
 
     Clean-ElasticAgentService
 
@@ -325,11 +343,11 @@ Function Clean-ElasticAgent {
 }
 
 Function Clean-ElasticAgentInstaller {
-    
-    $UninstallGuid = Get-AgentUninstallGUID
-    if (-not $UninstallGuid) { return }
+    param (
+        [string] $Path
+    )
 
-    Uninstall-MSI -Guid $UninstallGuid -LogToDir (Get-LogDir)
+    Uninstall-MSI -Path $Path -LogToDir (Get-LogDir)
 }
 
 Function Clean-ElasticAgentService {
@@ -358,10 +376,10 @@ Function Clean-ElasticAgentDirectory {
     }
 }
 
-Function Clean-ElasticAgentUninstallKeys {
-    $Keys = Get-AgentUninstallRegistryKey -Passthru
-    if ($Keys) {
-        $Keys | Remove-Item -force -verbose
+Function Clean-ElasticAgentManagedUninstallKey {
+    $ManagedKey = Get-AgentManagedUninstallRegistryKey -Passthru
+    if ($ManagedKey) {
+        $ManagedKey | Remove-Item -force -verbose
     }
 }
 

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -397,8 +397,7 @@ Function Clean-ElasticAgentProcess {
 }
 
 Function ForceStop-ElasticAgent {
-    # Clear SCM recovery actions so Windows does not auto-restart the service
-    # after we kill its process.
+    # Clear SCM recovery actions to prevent auto-restart after we kill the process.
     & sc.exe failure 'Elastic Agent' reset= 0 actions= '' | Out-Null
 
     Get-Process -Name 'elastic-agent' -ErrorAction SilentlyContinue | Stop-Process -Force

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -342,7 +342,7 @@ Function Show-AgentLogs {
         return
     }
 
-    $LogFiles = @(Get-ChildItem -Path "$DataRoot\*\logs" -Filter "*.ndjson" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime)
+    $LogFiles = @(Get-ChildItem -Path $DataRoot -Recurse -Filter "*.ndjson" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime)
     if ($LogFiles.Count -eq 0) {
         write-host "No agent log files under $DataRoot"
         return

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -236,7 +236,7 @@ Function Has-AgentFleetEnrollmentAttempt {
 
         $Content = Get-Content -raw $LogFile
 
-        if ($Content -like "*failed to perform delayed enrollment: fail to enroll: fail to execute request to fleet-server: lookup placeholder: no such host*") {
+        if ($Content -like "*fail to execute request to fleet-server: lookup placeholder: no such host*") {
             return $True
         }
 

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -397,12 +397,11 @@ Function Clean-ElasticAgentProcess {
 }
 
 Function ForceStop-ElasticAgent {
-    try {
-        Stop-Service -Name 'Elastic Agent' -Force -ErrorAction Stop
-    }
-    catch {
-        Get-Process -Name 'elastic-agent' -ErrorAction SilentlyContinue | Stop-Process -Force
-    }
+    # Clear SCM recovery actions so Windows does not auto-restart the service
+    # after we kill its process.
+    & sc.exe failure 'Elastic Agent' reset= 0 actions= '' | Out-Null
+
+    Get-Process -Name 'elastic-agent' -ErrorAction SilentlyContinue | Stop-Process -Force
     Wait-Process -Name 'elastic-agent' -Timeout 30 -ErrorAction SilentlyContinue
 }
 

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -396,6 +396,16 @@ Function Clean-ElasticAgentProcess {
     }
 }
 
+Function ForceStop-ElasticAgent {
+    try {
+        Stop-Service -Name 'Elastic Agent' -Force -ErrorAction Stop
+    }
+    catch {
+        Get-Process -Name 'elastic-agent' -ErrorAction SilentlyContinue | Stop-Process -Force
+    }
+    Wait-Process -Name 'elastic-agent' -Timeout 30 -ErrorAction SilentlyContinue
+}
+
 Function Clean-ElasticAgentDirectory {
     $Path = Join-Path ($Env:ProgramFiles) "Elastic\Agent"
     if (Test-Path $Path) {

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -321,7 +321,7 @@ Function Get-AgentLogFile {
         $Latest
     )
 
-    
+
     $LogFiles = @(Get-ChildItem -Path (get-item "C:\Program Files\Elastic\Agent\data\*\logs").fullname -Filter "*.ndjson" | Where-Object {$_.name -notlike "*watcher*"} | Sort-Object LastWriteTime)
 
     if ($LogFiles.Count -eq 0) {
@@ -330,9 +330,29 @@ Function Get-AgentLogFile {
 
     if ($Latest) {
         return $LogFiles | Select-Object -last 1
-    } 
+    }
 
     return $LogFiles
+}
+
+Function Show-AgentLogs {
+    $DataRoot = Join-Path $Script:AgentPath "data"
+    if (-not (Test-Path $DataRoot)) {
+        write-host "No agent data directory at $DataRoot"
+        return
+    }
+
+    $LogFiles = @(Get-ChildItem -Path "$DataRoot\*\logs" -Filter "*.ndjson" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime)
+    if ($LogFiles.Count -eq 0) {
+        write-host "No agent log files under $DataRoot"
+        return
+    }
+
+    foreach ($LogFile in $LogFiles) {
+        write-host "===== $($LogFile.FullName) ====="
+        Get-Content -Path $LogFile.FullName -ErrorAction SilentlyContinue | write-host
+        write-host "===== end $($LogFile.FullName) ====="
+    }
 }
 
 
@@ -441,12 +461,12 @@ Function Invoke-MSIExec {
         $Message = "msiexec reports error $($process.ExitCode) = $(Get-MSIErrorMessage -Code $Process.ExitCode)"
         try {
             if ($LogToDir -and $Action -eq "x") {
-                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.UnInstallAction' -Context 0,30
+                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.UnInstallAction' -Context 0,100
                 write-warning "Elastic Agent uninstall returned:"
                 write-warning ($CustomActionLog.Context.PostContext -join "`n")
             } elseif ($LogToDir -and $Action -eq "i") {
-                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.InstallAction' -Context 0,30
-                write-warning "Elastic Agent uninstall returned:"
+                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.InstallAction' -Context 0,100
+                write-warning "Elastic Agent install returned:"
                 write-warning ($CustomActionLog.Context.PostContext -join "`n")
             }
         } catch {
@@ -454,6 +474,9 @@ Function Invoke-MSIExec {
             write-warning "Dumping full MSI Log"
             write-host (Get-Content $LoggingDestination -raw)
         }
+
+        write-warning "Dumping elastic-agent logs for troubleshooting"
+        Show-AgentLogs
 
         write-verbose $Message
 

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -276,6 +276,18 @@ Function Is-AgentManagedUninstallKeyPresent {
     Return $false
 }
 
+Function Get-AgentVersion {
+    $path = (Join-Path $Script:AgentPath $Script:AgentBinary)
+    if (-not (Test-Path $path)) {
+        throw "Agent binary not found at $path; cannot determine version"
+    }
+    $versionString = (Get-Item $path).VersionInfo.ProductVersion
+    if (-not $versionString) {
+        throw "Could not read ProductVersion from $path"
+    }
+    return [version](($versionString -split '[-+]')[0])
+}
+
 Function Is-AgentInstallCacheGone {
     return (-not (Is-AgentInstallCachePresent))
 }

--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -459,15 +459,18 @@ Function Invoke-MSIExec {
 
     if ($process.ExitCode -ne 0) {
         $Message = "msiexec reports error $($process.ExitCode) = $(Get-MSIErrorMessage -Code $Process.ExitCode)"
+        $CustomActionOutput = ""
         try {
             if ($LogToDir -and $Action -eq "x") {
                 $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.UnInstallAction' -Context 0,100
+                $CustomActionOutput = ($CustomActionLog.Context.PostContext -join "`n")
                 write-warning "Elastic Agent uninstall returned:"
-                write-warning ($CustomActionLog.Context.PostContext -join "`n")
+                write-warning $CustomActionOutput
             } elseif ($LogToDir -and $Action -eq "i") {
                 $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.InstallAction' -Context 0,100
+                $CustomActionOutput = ($CustomActionLog.Context.PostContext -join "`n")
                 write-warning "Elastic Agent install returned:"
-                write-warning ($CustomActionLog.Context.PostContext -join "`n")
+                write-warning $CustomActionOutput
             }
         } catch {
             write-warning "Failed to parse msi log for errors"
@@ -477,6 +480,10 @@ Function Invoke-MSIExec {
 
         write-warning "Dumping elastic-agent logs for troubleshooting"
         Show-AgentLogs
+
+        if ($CustomActionOutput) {
+            $Message += "`n" + $CustomActionOutput
+        }
 
         write-verbose $Message
 

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -20,7 +20,8 @@ BeforeDiscovery {
                     write-warning "Agent Install Cache Program Files/Elastic/Beats is still present with $(Get-AgentInstallCacheCount) entries"
                 }
                 #Is-AgentInstallCachePresent | Should -BeFalse
-                Is-AgentUninstallKeyPresent | Should -BeTrue
+                Is-AgentManagedUninstallKeyPresent | Should -BeTrue
+                Is-AgentMSIUninstallKeyPresent | Should -BeFalse
                 Is-AgentBinaryPresent | Should -BeTrue
                 Is-AgentServicePresent | Should -BeTrue
                 Is-AgentServiceRunning -Resolve | Should -BeTrue # Start the service if it's not running and expect it to remain running
@@ -42,11 +43,12 @@ BeforeDiscovery {
                     write-warning "Agent Install Cache Program Files/Elastic/Beats is still present with $(Get-AgentInstallCacheCount) entries"
                 }
                 #Is-AgentInstallCachePresent | Should -BeFalse
-                Is-AgentUninstallKeyPresent | Should -BeTrue
+                Is-AgentManagedUninstallKeyPresent | Should -BeTrue
+                Is-AgentMSIUninstallKeyPresent | Should -BeFalse
                 Is-AgentBinaryPresent | Should -BeTrue
                 Is-AgentServicePresent | Should -BeTrue
 
-                # Start the service but don't expect it to be running as our fleet config causes agent to stop right away 
+                # Start the service but don't expect it to be running as our fleet config causes agent to stop right away
                 Is-AgentServiceRunning -Resolve -WaitForExit
 
                 Has-AgentLogged | Should -BeTrue
@@ -73,7 +75,7 @@ BeforeAll {
         Is-AgentFleetEnrolled | Should -BeFalse -Because "The agent should have been cleaned up already"
         Is-AgentServiceRunning | Should -BeFalse -Because "The agent should have been cleaned up already"
         Is-AgentServicePresent | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentUninstallKeyPresent | Should -BeFalse -Because "The agent should have been cleaned up already"
+        Is-AgentManagedUninstallKeyPresent | Should -BeFalse -Because "The agent should have been cleaned up already"
         Is-AgentInstallCachePresent | Should -BeFalse -Because "The agent should have been cleaned up already"
     }
 
@@ -83,7 +85,7 @@ BeforeAll {
     }
     catch {
         write-warning "Found Agent remnants before tests started. Removing Agent."
-        Clean-ElasticAgent
+        Clean-ElasticAgent -MSIPath $PathToLatestMSI
     }
 }
 
@@ -96,7 +98,7 @@ Describe 'Elastic Agent MSI Installer' {
         }
         catch {
             write-warning "Found Agent remnants between tests. Removing Agent."
-            Clean-ElasticAgent
+            Clean-ElasticAgent -MSIPath $PathToLatestMSI
         }
 
         # Reduce filesystem async race conditions - spooky voodoo
@@ -130,19 +132,6 @@ Describe 'Elastic Agent MSI Installer' {
             Check-AgentRemnants
         }
 
-        It 'Can be installed and uninstalled via GUID, without installargs, in <Mode> mode' {
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            Assert-AgentHealthy
-
-            { Get-AgentUninstallGUID } | Should -Not -Throw
-            $UninstallGuid = Get-AgentUninstallGUID
-
-            Uninstall-MSI -Guid $UninstallGuid @MSIUninstallParameters
-
-            Check-AgentRemnants
-        }
-        
         It 'Gracefully handles existing agent components' {
 
             # Create a fake service
@@ -167,10 +156,11 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
 
             # We clean-up with a clean-up script so that we can differentiate installer from uninstaller failures with the next test
-            Clean-ElasticAgent
+            Clean-ElasticAgent -MSIPath $PathToLatestMSI
 
             Check-AgentRemnants
         }
+
         It 'Blocks downgrades and upgrades in <Mode> mode' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
@@ -206,25 +196,13 @@ Describe 'Elastic Agent MSI Installer' {
                 & $HealthFunction
             }
         }
+
         It 'Behaves itself as a standalone agent' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
             Assert-AgentHealthy
 
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
-
-            Check-AgentRemnants
-        }
-        
-        It 'Can be installed in Standalone mode and uninstalled via GUID in default mode' {
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            Assert-AgentHealthy
-
-            { Get-AgentUninstallGUID } | Should -Not -Throw
-            $UninstallGuid = Get-AgentUninstallGUID
-
-            Uninstall-MSI -Guid $UninstallGuid @MSIUninstallParameters
 
             Check-AgentRemnants
         }
@@ -280,7 +258,7 @@ Describe 'Elastic Agent MSI Installer' {
             $Result | Should -Be 1603
 
             # QUIRK: Clean-up the leftovers as elastic-agent uninstall does not fully rollback during failure
-            Clean-ElasticAgent
+            Clean-ElasticAgent -MSIPath $PathToLatestMSI
             
             Check-AgentRemnants
         }
@@ -330,7 +308,6 @@ Describe 'Elastic Agent MSI Installer' {
             Check-AgentRemnants
         }
 
-
         It 'Can be installed and uninstalled via MSI, with invalid installargs, in fleet mode' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
@@ -339,19 +316,6 @@ Describe 'Elastic Agent MSI Installer' {
             { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--delayenroll"' } | Should -Throw
             
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
-
-            Check-AgentRemnants
-        }
-
-        It 'Can be installed in Fleet mode and uninstalled via GUID in default mode' {
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            Assert-AgentHealthy
-
-            { Get-AgentUninstallGUID } | Should -Not -Throw
-            $UninstallGuid = Get-AgentUninstallGUID
-
-            Uninstall-MSI -Guid $UninstallGuid @MSIUninstallParameters -Flags '/norestart'
 
             Check-AgentRemnants
         }

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -155,6 +155,10 @@ Describe 'Elastic Agent MSI Installer' {
 
             { Install-MSI -Path $PathToLatestMSI @MSIInstallParameters } | Should -Throw -ExpectedMessage '*service Elastic Agent already exists*'
 
+            if (Test-Path "C:\Program Files\Elastic\Agent\elastic-agent.exe") {
+                remove-item "C:\Program Files\Elastic\Agent\elastic-agent.exe"
+            }
+
             if ((Get-Service "Elastic Agent" -Erroraction SilentlyContinue).DisplayName -eq "Fake Service") {
                 Remove-Service "Elastic Agent"
             }

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -149,16 +149,10 @@ Describe 'Elastic Agent MSI Installer' {
 
             # Create a fake directory
             new-item -itemtype directory "C:\Program Files\Elastic\Agent\data\elastic-agent-03ef9d\logs"
-            
-            # Create a fake config
-            set-content "C:\Program Files\Elastic\Agent\elastic-agent.exe" -value "test" -nonewline
 
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
-            # Remove our fakes and see if everything passes 
-            if ((get-content "C:\Program Files\Elastic\Agent\elastic-agent.exe" -raw) -eq "test") {
-                remove-item "C:\Program Files\Elastic\Agent\elastic-agent.exe"
-            }
+            # Remove our fakes and see if everything passes
             if ((Get-Service "Elastic Agent" -Erroraction SilentlyContinue).DisplayName -eq "Fake Service") {
                 Remove-Service "Elastic Agent"
             }

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -160,6 +160,9 @@ Describe 'Elastic Agent MSI Installer' {
                 Remove-Service "Elastic Agent"
             }
 
+            # QUIRK: The MSI install cache is left behind when installation fails and must be removed manually
+            Clean-ElasticAgentDirectory
+
             Check-AgentRemnants
         }
 
@@ -264,9 +267,7 @@ Describe 'Elastic Agent MSI Installer' {
 
             $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent"
 
-            # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back,
-            # and so the test doesn't throw if the process has already exited between the poll
-            # check and the kill call.
+            # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back
             ForceStop-ElasticAgent
 
             $Job | Wait-Job
@@ -300,7 +301,6 @@ Describe 'Elastic Agent MSI Installer' {
 
             $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent"
 
-
             # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back
             ForceStop-ElasticAgent
 
@@ -310,6 +310,9 @@ Describe 'Elastic Agent MSI Installer' {
 
             # The interrupted install should fail with a 1603
             $Result | Should -Be 1603
+
+            # QUIRK: The MSI install cache is left behind when installation fails and must be removed manually
+            Clean-ElasticAgentDirectory
 
             Check-AgentRemnants
         }

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -20,8 +20,13 @@ BeforeDiscovery {
                     write-warning "Agent Install Cache Program Files/Elastic/Beats is still present with $(Get-AgentInstallCacheCount) entries"
                 }
                 #Is-AgentInstallCachePresent | Should -BeFalse
-                Is-AgentManagedUninstallKeyPresent | Should -BeTrue
-                Is-AgentMSIUninstallKeyPresent | Should -BeFalse
+                if ((Get-AgentVersion) -ge [version]'9.4.0') {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeTrue
+                    Is-AgentMSIUninstallKeyPresent | Should -BeFalse
+                } else {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeFalse
+                    Is-AgentMSIUninstallKeyPresent | Should -BeTrue
+                }
                 Is-AgentBinaryPresent | Should -BeTrue
                 Is-AgentServicePresent | Should -BeTrue
                 Is-AgentServiceRunning -Resolve | Should -BeTrue # Start the service if it's not running and expect it to remain running
@@ -43,8 +48,13 @@ BeforeDiscovery {
                     write-warning "Agent Install Cache Program Files/Elastic/Beats is still present with $(Get-AgentInstallCacheCount) entries"
                 }
                 #Is-AgentInstallCachePresent | Should -BeFalse
-                Is-AgentManagedUninstallKeyPresent | Should -BeTrue
-                Is-AgentMSIUninstallKeyPresent | Should -BeFalse
+                if ((Get-AgentVersion) -ge [version]'9.4.0') {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeTrue
+                    Is-AgentMSIUninstallKeyPresent | Should -BeFalse
+                } else {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeFalse
+                    Is-AgentMSIUninstallKeyPresent | Should -BeTrue
+                }
                 Is-AgentBinaryPresent | Should -BeTrue
                 Is-AgentServicePresent | Should -BeTrue
 

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -228,7 +228,7 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
-            { Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="--delayenroll"' } | Should -Throw
+            { Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="--invalid-flag"' } | Should -Throw
             
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
 
@@ -264,11 +264,14 @@ Describe 'Elastic Agent MSI Installer' {
 
             $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent"
 
-            Stop-Process -name "elastic-agent"
-            
+            # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back,
+            # and so the test doesn't throw if the process has already exited between the poll
+            # check and the kill call.
+            ForceStop-ElasticAgent
+
             $Job | Wait-Job
 
-            $Result = $Job | Receive-Job 
+            $Result = $Job | Receive-Job
 
             # The interrupted uninstall should fail with a 1603
             $Result | Should -Be 1603
@@ -280,32 +283,22 @@ Describe 'Elastic Agent MSI Installer' {
         }
 
         It 'Rollback install when elastic-agent install crashes' {
-            # Capture the background MSI's verbose log so we can see what happened inside the Start-Job
-            $JobMsiLog = Join-Path (Get-LogDir) ("rollback-install-bg-" + (Get-Date -Format 'HHmmss') + "-i.log")
-
             # Start the MSI in a background job so that we can kill a child process and measure success
             $Job = Start-Job -WorkingDirectory $PSScriptRoot -ScriptBlock {
-                $arglist = "/i $using:PathToLatestMSI /qn /l*v ""$using:JobMsiLog"" INSTALLARGS=""--delay-enroll --url=https://placeholder:443 --enrollment-token=token"""
+                $arglist = "/i $using:PathToLatestMSI /qn INSTALLARGS=""--delay-enroll --url=https://placeholder:443 --enrollment-token=token"""
                 write-information "msiexec $arglist "
                 $process = start-process -FilePath "msiexec.exe" -ArgumentList $arglist -wait -passthru
 
                 write-output $process.ExitCode
-            }
+            } 
 
             $Time = 0
             while (-not (get-process "elastic-agent" -erroraction silentlycontinue) -and $Time -lt 45) {
-                if ($Time % 5 -eq 0) {
-                    $procs = @(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Name -like '*elastic*' -or $_.Name -like '*msi*' } | ForEach-Object { "$($_.Name)(pid=$($_.Id))" }) -join ', '
-                    write-host "[${Time}s] Waiting for elastic-agent; job state=$($Job.State), procs: $procs"
-                }
                 start-sleep -seconds 1
                 $Time ++
             }
 
-            write-host "Finished waiting after ${Time}s; job state=$($Job.State). Partial job output follows:"
-            $Job | Receive-Job -Keep -ErrorAction SilentlyContinue | write-host
-
-            $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent (bg msi log: $JobMsiLog)"
+            $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent"
 
 
             # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back
@@ -347,7 +340,7 @@ Describe 'Elastic Agent MSI Installer' {
             # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
             ForceStop-ElasticAgent
 
-            { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--delayenroll"' } | Should -Throw
+            { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--invalid-flag"' } | Should -Throw
 
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
 

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -280,35 +280,43 @@ Describe 'Elastic Agent MSI Installer' {
         }
 
         It 'Rollback install when elastic-agent install crashes' {
+            # Capture the background MSI's verbose log so we can see what happened inside the Start-Job
+            $JobMsiLog = Join-Path (Get-LogDir) ("rollback-install-bg-" + (Get-Date -Format 'HHmmss') + "-i.log")
+
             # Start the MSI in a background job so that we can kill a child process and measure success
             $Job = Start-Job -WorkingDirectory $PSScriptRoot -ScriptBlock {
-                $arglist = "/i $using:PathToLatestMSI /qn INSTALLARGS=""--delay-enroll --url=https://placeholder:443 --enrollment-token=token"""
+                $arglist = "/i $using:PathToLatestMSI /qn /l*v ""$using:JobMsiLog"" INSTALLARGS=""--delay-enroll --url=https://placeholder:443 --enrollment-token=token"""
                 write-information "msiexec $arglist "
                 $process = start-process -FilePath "msiexec.exe" -ArgumentList $arglist -wait -passthru
 
                 write-output $process.ExitCode
-            } 
+            }
 
             $Time = 0
             while (-not (get-process "elastic-agent" -erroraction silentlycontinue) -and $Time -lt 45) {
+                if ($Time % 5 -eq 0) {
+                    $procs = @(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Name -like '*elastic*' -or $_.Name -like '*msi*' } | ForEach-Object { "$($_.Name)(pid=$($_.Id))" }) -join ', '
+                    write-host "[${Time}s] Waiting for elastic-agent; job state=$($Job.State), procs: $procs"
+                }
                 start-sleep -seconds 1
                 $Time ++
             }
 
-            $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent"
+            write-host "Finished waiting after ${Time}s; job state=$($Job.State). Partial job output follows:"
+            $Job | Receive-Job -Keep -ErrorAction SilentlyContinue | write-host
+
+            $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent (bg msi log: $JobMsiLog)"
 
 
-            Stop-Process -name "elastic-agent"
-            
+            # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back
+            ForceStop-ElasticAgent
+
             $Job | Wait-Job
 
-            $Result = $Job | Receive-Job 
+            $Result = $Job | Receive-Job
 
             # The interrupted install should fail with a 1603
             $Result | Should -Be 1603
-
-            # QUIRK: Clean-up the leftovers as elastic-agent install does not fully rollback during failure
-            Clean-ElasticAgentDirectory
 
             Check-AgentRemnants
         }

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -139,8 +139,9 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
 
             if ($Mode -eq 'Fleet') {
-                # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
                 # trying to enroll to a fake fleet server (https://placeholder:443)
+                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
                 ForceStop-ElasticAgent
             }
 
@@ -154,10 +155,6 @@ Describe 'Elastic Agent MSI Installer' {
             new-service -Name "Elastic Agent" -BinaryPathName "cmd.exe" -DisplayName "Fake Service" -StartupType manual
 
             { Install-MSI -Path $PathToLatestMSI @MSIInstallParameters } | Should -Throw -ExpectedMessage '*service Elastic Agent already exists*'
-
-            if (Test-Path "C:\Program Files\Elastic\Agent\elastic-agent.exe") {
-                remove-item "C:\Program Files\Elastic\Agent\elastic-agent.exe"
-            }
 
             if ((Get-Service "Elastic Agent" -Erroraction SilentlyContinue).DisplayName -eq "Fake Service") {
                 Remove-Service "Elastic Agent"
@@ -176,8 +173,9 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
 
             if ($Mode -eq 'Fleet') {
-                # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
                 # trying to enroll to a fake fleet server (https://placeholder:443)
+                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
                 ForceStop-ElasticAgent
             }
 
@@ -196,8 +194,9 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
 
             if ($Mode -eq 'Fleet') {
-                # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
                 # trying to enroll to a fake fleet server (https://placeholder:443)
+                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
                 ForceStop-ElasticAgent
             }
 
@@ -320,8 +319,9 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
             Has-AgentFleetEnrollmentAttempt | Should -BeTrue
 
-            # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+            # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
             # trying to enroll to a fake fleet server (https://placeholder:443)
+            # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
             ForceStop-ElasticAgent
 
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
@@ -334,8 +334,9 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
-            # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+            # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
             # trying to enroll to a fake fleet server (https://placeholder:443)
+            # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
             ForceStop-ElasticAgent
 
             { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--delayenroll"' } | Should -Throw

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -143,25 +143,15 @@ Describe 'Elastic Agent MSI Installer' {
             Check-AgentRemnants
         }
 
-        It 'Gracefully handles existing agent components in <Mode> mode' {
-
-            # Create a fake service
+        It 'Leaves no agent artifacts when install fails in <Mode> mode' {
+            # Pre-create a fake "Elastic Agent" service so the MSI install fails
             new-service -Name "Elastic Agent" -BinaryPathName "cmd.exe" -DisplayName "Fake Service" -StartupType manual
 
-            # Create a fake directory
-            new-item -itemtype directory "C:\Program Files\Elastic\Agent\data\elastic-agent-03ef9d\logs"
+            { Install-MSI -Path $PathToLatestMSI @MSIInstallParameters } | Should -Throw -ExpectedMessage '*service Elastic Agent already exists*'
 
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            # Remove our fakes and see if everything passes
             if ((Get-Service "Elastic Agent" -Erroraction SilentlyContinue).DisplayName -eq "Fake Service") {
                 Remove-Service "Elastic Agent"
             }
-
-            Assert-AgentHealthy
-
-            # We clean-up with a clean-up script so that we can differentiate installer from uninstaller failures with the next test
-            Clean-ElasticAgent -MSIPath $PathToLatestMSI
 
             Check-AgentRemnants
         }

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -81,12 +81,13 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "helpers.ps1") -Force -Verbose:$False
 
     Function Check-AgentRemnants {
-        Is-AgentBinaryPresent | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentFleetEnrolled | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentServiceRunning | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentServicePresent | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentManagedUninstallKeyPresent | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentInstallCachePresent | Should -BeFalse -Because "The agent should have been cleaned up already"
+        Is-AgentBinaryPresent | Should -BeFalse -Because "elastic-agent.exe is still on disk under C:\Program Files\Elastic\Agent"
+        Is-AgentFleetEnrolled | Should -BeFalse -Because "fleet.enc is still present, fleet enrollment was not torn down"
+        Is-AgentServiceRunning | Should -BeFalse -Because "the 'Elastic Agent' Windows service is still running"
+        Is-AgentServicePresent | Should -BeFalse -Because "the 'Elastic Agent' Windows service is still registered"
+        Is-AgentMSIUninstallKeyPresent | Should -BeFalse -Because "the MSI ARP uninstall entry (HKLM\...\Uninstall\{ProductCode}) is still present"
+        Is-AgentManagedUninstallKeyPresent | Should -BeFalse -Because "the agent-managed uninstall entry (HKLM\...\Uninstall\Elastic Agent) is still present"
+        Is-AgentInstallCachePresent | Should -BeFalse -Because "the MSI install cache at C:\Program Files\Elastic\Beats still exists"
     }
 
     # Perform an initial environment cleanup
@@ -142,7 +143,7 @@ Describe 'Elastic Agent MSI Installer' {
             Check-AgentRemnants
         }
 
-        It 'Gracefully handles existing agent components' {
+        It 'Gracefully handles existing agent components in <Mode> mode' {
 
             # Create a fake service
             new-service -Name "Elastic Agent" -BinaryPathName "cmd.exe" -DisplayName "Fake Service" -StartupType manual

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -138,6 +138,12 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
+            if ($Mode -eq 'Fleet') {
+                # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # trying to enroll to a fake fleet server (https://placeholder:443)
+                ForceStop-ElasticAgent
+            }
+
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
 
             Check-AgentRemnants
@@ -160,10 +166,16 @@ Describe 'Elastic Agent MSI Installer' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
             Assert-AgentHealthy
-            
+
             { Install-MSI -Path $PathToEarlyMSI -Interactive "/qn" @MSIInstallParameters } | Should -Throw
 
             Assert-AgentHealthy
+
+            if ($Mode -eq 'Fleet') {
+                # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # trying to enroll to a fake fleet server (https://placeholder:443)
+                ForceStop-ElasticAgent
+            }
 
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
 
@@ -178,6 +190,12 @@ Describe 'Elastic Agent MSI Installer' {
             { Install-MSI -Path $PathToLatestMSI -Interactive "/qn" @MSIInstallParameters } | Should -Throw
 
             Assert-AgentHealthy
+
+            if ($Mode -eq 'Fleet') {
+                # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # trying to enroll to a fake fleet server (https://placeholder:443)
+                ForceStop-ElasticAgent
+            }
 
             Uninstall-MSI -Path $PathToEarlyMSI
 
@@ -298,6 +316,10 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
             Has-AgentFleetEnrollmentAttempt | Should -BeTrue
 
+            # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+            # trying to enroll to a fake fleet server (https://placeholder:443)
+            ForceStop-ElasticAgent
+
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
 
             Check-AgentRemnants
@@ -308,8 +330,12 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
+            # Stop the agent to avoid the > 10 minute uninstall timeout while it's
+            # trying to enroll to a fake fleet server (https://placeholder:443)
+            ForceStop-ElasticAgent
+
             { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--delayenroll"' } | Should -Throw
-            
+
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
 
             Check-AgentRemnants

--- a/src/installer/BeatPackageCompiler/AgentCustomAction.cs
+++ b/src/installer/BeatPackageCompiler/AgentCustomAction.cs
@@ -32,9 +32,17 @@ namespace Elastic.PackageCompiler.Beats
                     // If agent got installed properly, we can go ahead and remove all the files installed by the MSI (best effort)
                     RemoveFolder(session, session["INSTALLDIR"]);
 
-                    // elastic-agent manages its own uninstall key at HKLM\...\Uninstall\Elastic Agent,
-                    // so the MSI's GUID-based ARP entry written by RegisterProduct is redundant.
-                    RemoveARPKey(session);
+                    // elastic-agent manages its own uninstall key so the MSI's written can be removed
+                    RemoveMSIUninstallKey(session);
+                }
+                else
+                {
+                    // The agent binary is left behind when installation fails and must be removed manually
+                    RemoveFile(session, @"C:\Program Files\Elastic\Agent\elastic-agent.exe");
+
+                    // The agent's managed uninstall key is left behind when installation fails and must be removed manually
+                    // TODO(samuevl): remove when https://github.com/elastic/elastic-agent/pull/13705 is released
+                    RemoveManagedUninstallKey(session);
                 }
 
                 return process.ExitCode == 0 ? ActionResult.Success : ActionResult.Failure;
@@ -72,7 +80,20 @@ namespace Elastic.PackageCompiler.Beats
             }
         }
 
-        private static void RemoveARPKey(Session session)
+        private static void RemoveFile(Session session, string file)
+        {
+            try
+            {
+                File.Delete(file);
+                session.Log("Successfully removed file: " + file);
+            }
+            catch (Exception ex)
+            {
+                session.Log("Failed to remove file: " + file + ", exception: " + ex.ToString());
+            }
+        }
+
+        private static void RemoveMSIUninstallKey(Session session)
         {
             try
             {
@@ -84,6 +105,20 @@ namespace Elastic.PackageCompiler.Beats
             catch (Exception ex)
             {
                 session.Log("Failed to remove ARP registry key: " + ex.ToString());
+            }
+        }
+
+        private static void RemoveManagedUninstallKey(Session session)
+        {
+            try
+            {
+                const string keyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Elastic Agent";
+                Registry.LocalMachine.DeleteSubKeyTree(keyPath, false);
+                session.Log("Removed agent-managed uninstall registry key: HKLM\\" + keyPath);
+            }
+            catch (Exception ex)
+            {
+                session.Log("Failed to remove agent-managed uninstall registry key: " + ex.ToString());
             }
         }
 

--- a/src/installer/BeatPackageCompiler/AgentCustomAction.cs
+++ b/src/installer/BeatPackageCompiler/AgentCustomAction.cs
@@ -32,11 +32,17 @@ namespace Elastic.PackageCompiler.Beats
                     // If agent got installed properly, we can go ahead and remove all the files installed by the MSI (best effort)
                     RemoveFolder(session, session["INSTALLDIR"]);
 
-                    // elastic-agent manages its own uninstall key so the MSI's written can be removed
+                    // The agent handles its own lifecycle and should not expose a standard MSI uninstall entry
+                    // in the Windows registry
                     RemoveMSIUninstallKey(session);
                 }
                 else
                 {
+                    // The MSI install cache is left behind when installation fails and must be removed manually
+                    string installDir = session["INSTALLDIR"].TrimEnd('\\');
+                    string beatsRoot = Path.GetDirectoryName(Path.GetDirectoryName(installDir));
+                    RemoveFolder(session, beatsRoot);
+
                     // The agent binary is left behind when installation fails and must be removed manually
                     RemoveFile(session, @"C:\Program Files\Elastic\Agent\elastic-agent.exe");
 
@@ -84,8 +90,11 @@ namespace Elastic.PackageCompiler.Beats
         {
             try
             {
+                bool existedBefore = File.Exists(file);
+                session.Log("RemoveFile: File.Exists(" + file + ") = " + existedBefore);
                 File.Delete(file);
-                session.Log("Successfully removed file: " + file);
+                bool existsAfter = File.Exists(file);
+                session.Log("RemoveFile: after delete, File.Exists = " + existsAfter);
             }
             catch (Exception ex)
             {
@@ -113,8 +122,15 @@ namespace Elastic.PackageCompiler.Beats
             try
             {
                 const string keyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Elastic Agent";
+                using (var existing = Registry.LocalMachine.OpenSubKey(keyPath))
+                {
+                    session.Log("RemoveManagedUninstallKey: key exists before delete = " + (existing != null));
+                }
                 Registry.LocalMachine.DeleteSubKeyTree(keyPath, false);
-                session.Log("Removed agent-managed uninstall registry key: HKLM\\" + keyPath);
+                using (var afterDelete = Registry.LocalMachine.OpenSubKey(keyPath))
+                {
+                    session.Log("RemoveManagedUninstallKey: key exists after delete = " + (afterDelete != null));
+                }
             }
             catch (Exception ex)
             {

--- a/src/installer/BeatPackageCompiler/AgentCustomAction.cs
+++ b/src/installer/BeatPackageCompiler/AgentCustomAction.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.Win32;
 
 namespace Elastic.PackageCompiler.Beats
 {
@@ -30,6 +31,10 @@ namespace Elastic.PackageCompiler.Beats
                 {
                     // If agent got installed properly, we can go ahead and remove all the files installed by the MSI (best effort)
                     RemoveFolder(session, session["INSTALLDIR"]);
+
+                    // elastic-agent manages its own uninstall key at HKLM\...\Uninstall\Elastic Agent,
+                    // so the MSI's GUID-based ARP entry written by RegisterProduct is redundant.
+                    RemoveARPKey(session);
                 }
 
                 return process.ExitCode == 0 ? ActionResult.Success : ActionResult.Failure;
@@ -64,6 +69,21 @@ namespace Elastic.PackageCompiler.Beats
             catch (Exception ex)
             {
                 session.Log("Failed to remove folder: " + folder + ", exception: " + ex.ToString());
+            }
+        }
+
+        private static void RemoveARPKey(Session session)
+        {
+            try
+            {
+                string productCode = session["ProductCode"];
+                string keyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\" + productCode;
+                Registry.LocalMachine.DeleteSubKeyTree(keyPath, false);
+                session.Log("Removed ARP registry key: HKLM\\" + keyPath);
+            }
+            catch (Exception ex)
+            {
+                session.Log("Failed to remove ARP registry key: " + ex.ToString());
             }
         }
 

--- a/src/installer/BeatPackageCompiler/AgentCustomAction.cs
+++ b/src/installer/BeatPackageCompiler/AgentCustomAction.cs
@@ -38,11 +38,6 @@ namespace Elastic.PackageCompiler.Beats
                 }
                 else
                 {
-                    // The MSI install cache is left behind when installation fails and must be removed manually
-                    string installDir = session["INSTALLDIR"].TrimEnd('\\');
-                    string beatsRoot = Path.GetDirectoryName(Path.GetDirectoryName(installDir));
-                    RemoveFolder(session, beatsRoot);
-
                     // The agent binary is left behind when installation fails and must be removed manually
                     RemoveFile(session, @"C:\Program Files\Elastic\Agent\elastic-agent.exe");
 
@@ -90,11 +85,8 @@ namespace Elastic.PackageCompiler.Beats
         {
             try
             {
-                bool existedBefore = File.Exists(file);
-                session.Log("RemoveFile: File.Exists(" + file + ") = " + existedBefore);
                 File.Delete(file);
-                bool existsAfter = File.Exists(file);
-                session.Log("RemoveFile: after delete, File.Exists = " + existsAfter);
+                session.Log("Successfully removed file: " + file);
             }
             catch (Exception ex)
             {
@@ -122,15 +114,8 @@ namespace Elastic.PackageCompiler.Beats
             try
             {
                 const string keyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Elastic Agent";
-                using (var existing = Registry.LocalMachine.OpenSubKey(keyPath))
-                {
-                    session.Log("RemoveManagedUninstallKey: key exists before delete = " + (existing != null));
-                }
                 Registry.LocalMachine.DeleteSubKeyTree(keyPath, false);
-                using (var afterDelete = Registry.LocalMachine.OpenSubKey(keyPath))
-                {
-                    session.Log("RemoveManagedUninstallKey: key exists after delete = " + (afterDelete != null));
-                }
+                session.Log("Removed agent-managed uninstall registry key: HKLM\\" + keyPath);
             }
             catch (Exception ex)
             {

--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -177,6 +177,11 @@ namespace Elastic.PackageCompiler.Beats
             // When uninstalling, the 'elastic-agent uninstall' command.
             if (pc.IsAgent)
             {
+                // Hide from Add/Remove Programs and suppress the uninstall registry entry.
+                // The elastic-agent handles its own lifecycle and should not expose a
+                // standard MSI uninstall entry in the Windows registry.
+                project.AddProperty(new Property("ARPSYSTEMCOMPONENT", "1"));
+
                 // https://stackoverflow.com/a/311837
                 project.LaunchConditions.Add(new LaunchCondition("Privileged", "Elastic Agent MSI must run as an administrator"));
                 project.AddProperty(new Property("MSIUSEREALADMINDETECTION", "1"));

--- a/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
+++ b/src/installer/BeatPackageCompiler/BeatPackageCompiler.cs
@@ -177,11 +177,6 @@ namespace Elastic.PackageCompiler.Beats
             // When uninstalling, the 'elastic-agent uninstall' command.
             if (pc.IsAgent)
             {
-                // Hide from Add/Remove Programs and suppress the uninstall registry entry.
-                // The elastic-agent handles its own lifecycle and should not expose a
-                // standard MSI uninstall entry in the Windows registry.
-                project.AddProperty(new Property("ARPSYSTEMCOMPONENT", "1"));
-
                 // https://stackoverflow.com/a/311837
                 project.LaunchConditions.Add(new LaunchCondition("Privileged", "Elastic Agent MSI must run as an administrator"));
                 project.AddProperty(new Property("MSIUSEREALADMINDETECTION", "1"));


### PR DESCRIPTION
The elastic-agent now manages its own uninstall registry key at `HKLM:\...\Uninstall\Elastic Agent`. To avoid a duplicate entry in Add/Remove Programs, the MSI's InstallAction custom action deletes the redundant GUID-based ARP entry after RegisterProduct writes it, leaving only the agent-managed key visible.

This needs https://github.com/elastic/elastic-agent/pull/13316 to be merged first.