### PR TITLE
[9.4] (backport #350) feature(agent): skip MSI uninstall registry entry in favor of managed key

### DIFF
--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -8,7 +8,7 @@ Function Get-LogDir {
     return $Script:LogDir
 }
 
-Function Get-AgentUninstallRegistryKey {
+Function Get-AgentMSIUninstallRegistryKey {
     param (
         [switch] $Passthru
     )
@@ -23,14 +23,19 @@ Function Get-AgentUninstallRegistryKey {
     return $Result.Name
 }
 
-Function Get-AgentUninstallGUID {
-    $RegistryKey = Get-AgentUninstallRegistryKey -Passthru
+Function Get-AgentManagedUninstallRegistryKey {
+    param (
+        [switch] $Passthru
+    )
 
-    try {
-        $GUID = $RegistryKey.PSChildName
-        return $GUID
-    }
-    catch {}
+    $KeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Elastic Agent"
+    if (-not (Test-Path $KeyPath)) { return; }
+
+    $Result = Get-Item $KeyPath
+
+    if ($Passthru) { return $Result }
+
+    return $Result.Name
 }
 
 Function Run-AgentChecks {
@@ -231,7 +236,7 @@ Function Has-AgentFleetEnrollmentAttempt {
 
         $Content = Get-Content -raw $LogFile
 
-        if ($Content -like "*failed to perform delayed enrollment: fail to enroll: fail to execute request to fleet-server: lookup placeholder: no such host*") {
+        if ($Content -like "*fail to execute request to fleet-server: lookup placeholder: no such host*") {
             return $True
         }
 
@@ -253,14 +258,34 @@ Function Is-AgentFleetEnrolled {
     return $false
 }
 
-Function Is-AgentUninstallKeyPresent {
-
-    $RegistryKey = @(Get-AgentUninstallRegistryKey)
+Function Is-AgentMSIUninstallKeyPresent {
+    $RegistryKey = @(Get-AgentMSIUninstallRegistryKey)
     if ($RegistryKey.length -ne 0) {
         return $true
     }
 
     Return $false
+}
+
+Function Is-AgentManagedUninstallKeyPresent {
+    $RegistryKey = @(Get-AgentManagedUninstallRegistryKey)
+    if ($RegistryKey.length -ne 0) {
+        return $true
+    }
+
+    Return $false
+}
+
+Function Get-AgentVersion {
+    $path = (Join-Path $Script:AgentPath $Script:AgentBinary)
+    if (-not (Test-Path $path)) {
+        throw "Agent binary not found at $path; cannot determine version"
+    }
+    $versionString = (Get-Item $path).VersionInfo.ProductVersion
+    if (-not $versionString) {
+        throw "Could not read ProductVersion from $path"
+    }
+    return [version](($versionString -split '[-+]')[0])
 }
 
 Function Is-AgentInstallCacheGone {
@@ -296,7 +321,7 @@ Function Get-AgentLogFile {
         $Latest
     )
 
-    
+
     $LogFiles = @(Get-ChildItem -Path (get-item "C:\Program Files\Elastic\Agent\data\*\logs").fullname -Filter "*.ndjson" | Where-Object {$_.name -notlike "*watcher*"} | Sort-Object LastWriteTime)
 
     if ($LogFiles.Count -eq 0) {
@@ -305,17 +330,42 @@ Function Get-AgentLogFile {
 
     if ($Latest) {
         return $LogFiles | Select-Object -last 1
-    } 
+    }
 
     return $LogFiles
 }
 
+Function Show-AgentLogs {
+    $DataRoot = Join-Path $Script:AgentPath "data"
+    if (-not (Test-Path $DataRoot)) {
+        write-host "No agent data directory at $DataRoot"
+        return
+    }
+
+    $LogFiles = @(Get-ChildItem -Path $DataRoot -Recurse -Filter "*.ndjson" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime)
+    if ($LogFiles.Count -eq 0) {
+        write-host "No agent log files under $DataRoot"
+        return
+    }
+
+    foreach ($LogFile in $LogFiles) {
+        write-host "===== $($LogFile.FullName) ====="
+        Get-Content -Path $LogFile.FullName -ErrorAction SilentlyContinue | write-host
+        write-host "===== end $($LogFile.FullName) ====="
+    }
+}
+
 
 Function Clean-ElasticAgent {
+    param (
+        [string] $MSIPath
+    )
 
-    try { Clean-ElasticAgentInstaller } catch { }
+    if ($MSIPath) {
+        try { Clean-ElasticAgentInstaller -Path $MSIPath } catch { }
+    }
 
-    Clean-ElasticAgentUninstallKeys
+    Clean-ElasticAgentManagedUninstallKey
 
     Clean-ElasticAgentService
 
@@ -325,11 +375,11 @@ Function Clean-ElasticAgent {
 }
 
 Function Clean-ElasticAgentInstaller {
-    
-    $UninstallGuid = Get-AgentUninstallGUID
-    if (-not $UninstallGuid) { return }
+    param (
+        [string] $Path
+    )
 
-    Uninstall-MSI -Guid $UninstallGuid -LogToDir (Get-LogDir)
+    Uninstall-MSI -Path $Path -LogToDir (Get-LogDir)
 }
 
 Function Clean-ElasticAgentService {
@@ -346,6 +396,14 @@ Function Clean-ElasticAgentProcess {
     }
 }
 
+Function ForceStop-ElasticAgent {
+    # Clear SCM recovery actions to prevent auto-restart after we kill the process.
+    & sc.exe failure 'Elastic Agent' reset= 0 actions= '' | Out-Null
+
+    Get-Process -Name 'elastic-agent' -ErrorAction SilentlyContinue | Stop-Process -Force
+    Wait-Process -Name 'elastic-agent' -Timeout 30 -ErrorAction SilentlyContinue
+}
+
 Function Clean-ElasticAgentDirectory {
     $Path = Join-Path ($Env:ProgramFiles) "Elastic\Agent"
     if (Test-Path $Path) {
@@ -358,10 +416,10 @@ Function Clean-ElasticAgentDirectory {
     }
 }
 
-Function Clean-ElasticAgentUninstallKeys {
-    $Keys = Get-AgentUninstallRegistryKey -Passthru
-    if ($Keys) {
-        $Keys | Remove-Item -force -verbose
+Function Clean-ElasticAgentManagedUninstallKey {
+    $ManagedKey = Get-AgentManagedUninstallRegistryKey -Passthru
+    if ($ManagedKey) {
+        $ManagedKey | Remove-Item -force -verbose
     }
 }
 
@@ -409,20 +467,30 @@ Function Invoke-MSIExec {
 
     if ($process.ExitCode -ne 0) {
         $Message = "msiexec reports error $($process.ExitCode) = $(Get-MSIErrorMessage -Code $Process.ExitCode)"
+        $CustomActionOutput = ""
         try {
             if ($LogToDir -and $Action -eq "x") {
-                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.UnInstallAction' -Context 0,30
+                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.UnInstallAction' -Context 0,100
+                $CustomActionOutput = ($CustomActionLog.Context.PostContext -join "`n")
                 write-warning "Elastic Agent uninstall returned:"
-                write-warning ($CustomActionLog.Context.PostContext -join "`n")
+                write-warning $CustomActionOutput
             } elseif ($LogToDir -and $Action -eq "i") {
-                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.InstallAction' -Context 0,30
-                write-warning "Elastic Agent uninstall returned:"
-                write-warning ($CustomActionLog.Context.PostContext -join "`n")
+                $CustomActionLog = Select-String -Path $LoggingDestination -Pattern 'Calling custom action BeatPackageCompiler!Elastic.PackageCompiler.Beats.AgentCustomAction.InstallAction' -Context 0,100
+                $CustomActionOutput = ($CustomActionLog.Context.PostContext -join "`n")
+                write-warning "Elastic Agent install returned:"
+                write-warning $CustomActionOutput
             }
         } catch {
             write-warning "Failed to parse msi log for errors"
             write-warning "Dumping full MSI Log"
             write-host (Get-Content $LoggingDestination -raw)
+        }
+
+        write-warning "Dumping elastic-agent logs for troubleshooting"
+        Show-AgentLogs
+
+        if ($CustomActionOutput) {
+            $Message += "`n" + $CustomActionOutput
         }
 
         write-verbose $Message

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -20,7 +20,13 @@ BeforeDiscovery {
                     write-warning "Agent Install Cache Program Files/Elastic/Beats is still present with $(Get-AgentInstallCacheCount) entries"
                 }
                 #Is-AgentInstallCachePresent | Should -BeFalse
-                Is-AgentUninstallKeyPresent | Should -BeTrue
+                if ((Get-AgentVersion) -ge [version]'9.4.0') {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeTrue
+                    Is-AgentMSIUninstallKeyPresent | Should -BeFalse
+                } else {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeFalse
+                    Is-AgentMSIUninstallKeyPresent | Should -BeTrue
+                }
                 Is-AgentBinaryPresent | Should -BeTrue
                 Is-AgentServicePresent | Should -BeTrue
                 Is-AgentServiceRunning -Resolve | Should -BeTrue # Start the service if it's not running and expect it to remain running
@@ -42,11 +48,17 @@ BeforeDiscovery {
                     write-warning "Agent Install Cache Program Files/Elastic/Beats is still present with $(Get-AgentInstallCacheCount) entries"
                 }
                 #Is-AgentInstallCachePresent | Should -BeFalse
-                Is-AgentUninstallKeyPresent | Should -BeTrue
+                if ((Get-AgentVersion) -ge [version]'9.4.0') {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeTrue
+                    Is-AgentMSIUninstallKeyPresent | Should -BeFalse
+                } else {
+                    Is-AgentManagedUninstallKeyPresent | Should -BeFalse
+                    Is-AgentMSIUninstallKeyPresent | Should -BeTrue
+                }
                 Is-AgentBinaryPresent | Should -BeTrue
                 Is-AgentServicePresent | Should -BeTrue
 
-                # Start the service but don't expect it to be running as our fleet config causes agent to stop right away 
+                # Start the service but don't expect it to be running as our fleet config causes agent to stop right away
                 Is-AgentServiceRunning -Resolve -WaitForExit
 
                 Has-AgentLogged | Should -BeTrue
@@ -69,12 +81,13 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot "helpers.ps1") -Force -Verbose:$False
 
     Function Check-AgentRemnants {
-        Is-AgentBinaryPresent | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentFleetEnrolled | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentServiceRunning | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentServicePresent | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentUninstallKeyPresent | Should -BeFalse -Because "The agent should have been cleaned up already"
-        Is-AgentInstallCachePresent | Should -BeFalse -Because "The agent should have been cleaned up already"
+        Is-AgentBinaryPresent | Should -BeFalse -Because "elastic-agent.exe is still on disk under C:\Program Files\Elastic\Agent"
+        Is-AgentFleetEnrolled | Should -BeFalse -Because "fleet.enc is still present, fleet enrollment was not torn down"
+        Is-AgentServiceRunning | Should -BeFalse -Because "the 'Elastic Agent' Windows service is still running"
+        Is-AgentServicePresent | Should -BeFalse -Because "the 'Elastic Agent' Windows service is still registered"
+        Is-AgentMSIUninstallKeyPresent | Should -BeFalse -Because "the MSI ARP uninstall entry (HKLM\...\Uninstall\{ProductCode}) is still present"
+        Is-AgentManagedUninstallKeyPresent | Should -BeFalse -Because "the agent-managed uninstall entry (HKLM\...\Uninstall\Elastic Agent) is still present"
+        Is-AgentInstallCachePresent | Should -BeFalse -Because "the MSI install cache at C:\Program Files\Elastic\Beats still exists"
     }
 
     # Perform an initial environment cleanup
@@ -83,7 +96,7 @@ BeforeAll {
     }
     catch {
         write-warning "Found Agent remnants before tests started. Removing Agent."
-        Clean-ElasticAgent
+        Clean-ElasticAgent -MSIPath $PathToLatestMSI
     }
 }
 
@@ -96,7 +109,7 @@ Describe 'Elastic Agent MSI Installer' {
         }
         catch {
             write-warning "Found Agent remnants between tests. Removing Agent."
-            Clean-ElasticAgent
+            Clean-ElasticAgent -MSIPath $PathToLatestMSI
         }
 
         # Reduce filesystem async race conditions - spooky voodoo
@@ -125,60 +138,49 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
+            if ($Mode -eq 'Fleet') {
+                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # trying to enroll to a fake fleet server (https://placeholder:443)
+                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
+                ForceStop-ElasticAgent
+            }
+
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
 
             Check-AgentRemnants
         }
 
-        It 'Can be installed and uninstalled via GUID, without installargs, in <Mode> mode' {
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            Assert-AgentHealthy
-
-            { Get-AgentUninstallGUID } | Should -Not -Throw
-            $UninstallGuid = Get-AgentUninstallGUID
-
-            Uninstall-MSI -Guid $UninstallGuid @MSIUninstallParameters
-
-            Check-AgentRemnants
-        }
-        
-        It 'Gracefully handles existing agent components' {
-
-            # Create a fake service
+        It 'Leaves no agent artifacts when install fails in <Mode> mode' {
+            # Pre-create a fake "Elastic Agent" service so the MSI install fails
             new-service -Name "Elastic Agent" -BinaryPathName "cmd.exe" -DisplayName "Fake Service" -StartupType manual
 
-            # Create a fake directory
-            new-item -itemtype directory "C:\Program Files\Elastic\Agent\data\elastic-agent-03ef9d\logs"
-            
-            # Create a fake config
-            set-content "C:\Program Files\Elastic\Agent\elastic-agent.exe" -value "test" -nonewline
+            { Install-MSI -Path $PathToLatestMSI @MSIInstallParameters } | Should -Throw -ExpectedMessage '*service Elastic Agent already exists*'
 
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            # Remove our fakes and see if everything passes 
-            if ((get-content "C:\Program Files\Elastic\Agent\elastic-agent.exe" -raw) -eq "test") {
-                remove-item "C:\Program Files\Elastic\Agent\elastic-agent.exe"
-            }
             if ((Get-Service "Elastic Agent" -Erroraction SilentlyContinue).DisplayName -eq "Fake Service") {
                 Remove-Service "Elastic Agent"
             }
 
-            Assert-AgentHealthy
-
-            # We clean-up with a clean-up script so that we can differentiate installer from uninstaller failures with the next test
-            Clean-ElasticAgent
+            # QUIRK: The MSI install cache is left behind when installation fails and must be removed manually
+            Clean-ElasticAgentDirectory
 
             Check-AgentRemnants
         }
+
         It 'Blocks downgrades and upgrades in <Mode> mode' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
             Assert-AgentHealthy
-            
+
             { Install-MSI -Path $PathToEarlyMSI -Interactive "/qn" @MSIInstallParameters } | Should -Throw
 
             Assert-AgentHealthy
+
+            if ($Mode -eq 'Fleet') {
+                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # trying to enroll to a fake fleet server (https://placeholder:443)
+                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
+                ForceStop-ElasticAgent
+            }
 
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
 
@@ -194,6 +196,13 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
+            if ($Mode -eq 'Fleet') {
+                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
+                # trying to enroll to a fake fleet server (https://placeholder:443)
+                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
+                ForceStop-ElasticAgent
+            }
+
             Uninstall-MSI -Path $PathToEarlyMSI
 
             Check-AgentRemnants
@@ -206,6 +215,7 @@ Describe 'Elastic Agent MSI Installer' {
                 & $HealthFunction
             }
         }
+
         It 'Behaves itself as a standalone agent' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
@@ -215,26 +225,13 @@ Describe 'Elastic Agent MSI Installer' {
 
             Check-AgentRemnants
         }
-        
-        It 'Can be installed in Standalone mode and uninstalled via GUID in default mode' {
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            Assert-AgentHealthy
-
-            { Get-AgentUninstallGUID } | Should -Not -Throw
-            $UninstallGuid = Get-AgentUninstallGUID
-
-            Uninstall-MSI -Guid $UninstallGuid @MSIUninstallParameters
-
-            Check-AgentRemnants
-        }
 
         It 'Can be installed and uninstalled via MSI, with invalid installargs, in standalone mode' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
             Assert-AgentHealthy
 
-            { Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="--delayenroll"' } | Should -Throw
+            { Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="--invalid-flag"' } | Should -Throw
             
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
 
@@ -270,17 +267,18 @@ Describe 'Elastic Agent MSI Installer' {
 
             $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent"
 
-            Stop-Process -name "elastic-agent"
-            
+            # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back
+            ForceStop-ElasticAgent
+
             $Job | Wait-Job
 
-            $Result = $Job | Receive-Job 
+            $Result = $Job | Receive-Job
 
             # The interrupted uninstall should fail with a 1603
             $Result | Should -Be 1603
 
             # QUIRK: Clean-up the leftovers as elastic-agent uninstall does not fully rollback during failure
-            Clean-ElasticAgent
+            Clean-ElasticAgent -MSIPath $PathToLatestMSI
             
             Check-AgentRemnants
         }
@@ -303,17 +301,17 @@ Describe 'Elastic Agent MSI Installer' {
 
             $Time | Should -BelessThan 45 -Because "otherwise we timed out waiting for the agent"
 
+            # Kill via ForceStop so SCM doesn't auto-restart the service while MSI rolls back
+            ForceStop-ElasticAgent
 
-            Stop-Process -name "elastic-agent"
-            
             $Job | Wait-Job
 
-            $Result = $Job | Receive-Job 
+            $Result = $Job | Receive-Job
 
             # The interrupted install should fail with a 1603
             $Result | Should -Be 1603
 
-            # QUIRK: Clean-up the leftovers as elastic-agent install does not fully rollback during failure
+            # QUIRK: The MSI install cache is left behind when installation fails and must be removed manually
             Clean-ElasticAgentDirectory
 
             Check-AgentRemnants
@@ -325,33 +323,29 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
             Has-AgentFleetEnrollmentAttempt | Should -BeTrue
 
+            # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
+            # trying to enroll to a fake fleet server (https://placeholder:443)
+            # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
+            ForceStop-ElasticAgent
+
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
 
             Check-AgentRemnants
         }
-
 
         It 'Can be installed and uninstalled via MSI, with invalid installargs, in fleet mode' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
             Assert-AgentHealthy
 
-            { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--delayenroll"' } | Should -Throw
-            
+            # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
+            # trying to enroll to a fake fleet server (https://placeholder:443)
+            # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
+            ForceStop-ElasticAgent
+
+            { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--invalid-flag"' } | Should -Throw
+
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
-
-            Check-AgentRemnants
-        }
-
-        It 'Can be installed in Fleet mode and uninstalled via GUID in default mode' {
-            Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
-
-            Assert-AgentHealthy
-
-            { Get-AgentUninstallGUID } | Should -Not -Throw
-            $UninstallGuid = Get-AgentUninstallGUID
-
-            Uninstall-MSI -Guid $UninstallGuid @MSIUninstallParameters -Flags '/norestart'
 
             Check-AgentRemnants
         }

--- a/src/installer/BeatPackageCompiler/AgentCustomAction.cs
+++ b/src/installer/BeatPackageCompiler/AgentCustomAction.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.Win32;
 
 namespace Elastic.PackageCompiler.Beats
 {
@@ -30,6 +31,19 @@ namespace Elastic.PackageCompiler.Beats
                 {
                     // If agent got installed properly, we can go ahead and remove all the files installed by the MSI (best effort)
                     RemoveFolder(session, session["INSTALLDIR"]);
+
+                    // The agent handles its own lifecycle and should not expose a standard MSI uninstall entry
+                    // in the Windows registry
+                    RemoveMSIUninstallKey(session);
+                }
+                else
+                {
+                    // The agent binary is left behind when installation fails and must be removed manually
+                    RemoveFile(session, @"C:\Program Files\Elastic\Agent\elastic-agent.exe");
+
+                    // The agent's managed uninstall key is left behind when installation fails and must be removed manually
+                    // TODO(samuevl): remove when https://github.com/elastic/elastic-agent/pull/13705 is released
+                    RemoveManagedUninstallKey(session);
                 }
 
                 return process.ExitCode == 0 ? ActionResult.Success : ActionResult.Failure;
@@ -64,6 +78,48 @@ namespace Elastic.PackageCompiler.Beats
             catch (Exception ex)
             {
                 session.Log("Failed to remove folder: " + folder + ", exception: " + ex.ToString());
+            }
+        }
+
+        private static void RemoveFile(Session session, string file)
+        {
+            try
+            {
+                File.Delete(file);
+                session.Log("Successfully removed file: " + file);
+            }
+            catch (Exception ex)
+            {
+                session.Log("Failed to remove file: " + file + ", exception: " + ex.ToString());
+            }
+        }
+
+        private static void RemoveMSIUninstallKey(Session session)
+        {
+            try
+            {
+                string productCode = session["ProductCode"];
+                string keyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\" + productCode;
+                Registry.LocalMachine.DeleteSubKeyTree(keyPath, false);
+                session.Log("Removed ARP registry key: HKLM\\" + keyPath);
+            }
+            catch (Exception ex)
+            {
+                session.Log("Failed to remove ARP registry key: " + ex.ToString());
+            }
+        }
+
+        private static void RemoveManagedUninstallKey(Session session)
+        {
+            try
+            {
+                const string keyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Elastic Agent";
+                Registry.LocalMachine.DeleteSubKeyTree(keyPath, false);
+                session.Log("Removed agent-managed uninstall registry key: HKLM\\" + keyPath);
+            }
+            catch (Exception ex)
+            {
+                session.Log("Failed to remove agent-managed uninstall registry key: " + ex.ToString());
             }
         }
 


### PR DESCRIPTION
Backport of https://github.com/elastic/elastic-stack-installers/pull/350