### PR TITLE
chore(agent): remove workarounds for released elastic-agent fixes

### DIFF
--- a/src/agent-qa/helpers.ps1
+++ b/src/agent-qa/helpers.ps1
@@ -355,7 +355,6 @@ Function Show-AgentLogs {
     }
 }
 
-
 Function Clean-ElasticAgent {
     param (
         [string] $MSIPath

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -138,13 +138,6 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
-            if ($Mode -eq 'Fleet') {
-                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
-                # trying to enroll to a fake fleet server (https://placeholder:443)
-                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
-                ForceStop-ElasticAgent
-            }
-
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters -Flags 'INSTALLARGS="-v"'
 
             Check-AgentRemnants
@@ -175,13 +168,6 @@ Describe 'Elastic Agent MSI Installer' {
 
             Assert-AgentHealthy
 
-            if ($Mode -eq 'Fleet') {
-                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
-                # trying to enroll to a fake fleet server (https://placeholder:443)
-                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
-                ForceStop-ElasticAgent
-            }
-
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
 
             Check-AgentRemnants
@@ -195,13 +181,6 @@ Describe 'Elastic Agent MSI Installer' {
             { Install-MSI -Path $PathToLatestMSI -Interactive "/qn" @MSIInstallParameters } | Should -Throw
 
             Assert-AgentHealthy
-
-            if ($Mode -eq 'Fleet') {
-                # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
-                # trying to enroll to a fake fleet server (https://placeholder:443)
-                # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
-                ForceStop-ElasticAgent
-            }
 
             Uninstall-MSI -Path $PathToEarlyMSI
 
@@ -323,11 +302,6 @@ Describe 'Elastic Agent MSI Installer' {
             Assert-AgentHealthy
             Has-AgentFleetEnrollmentAttempt | Should -BeTrue
 
-            # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
-            # trying to enroll to a fake fleet server (https://placeholder:443)
-            # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
-            ForceStop-ElasticAgent
-
             Uninstall-MSI -Path $PathToLatestMSI @MSIUninstallParameters
 
             Check-AgentRemnants
@@ -337,11 +311,6 @@ Describe 'Elastic Agent MSI Installer' {
             Install-MSI -Path $PathToLatestMSI @MSIInstallParameters
 
             Assert-AgentHealthy
-
-            # Workaround to stop the agent to avoid the > 10 minute uninstall timeout while it's
-            # trying to enroll to a fake fleet server (https://placeholder:443)
-            # TODO(samuelvl): remove when https://github.com/elastic/elastic-agent/pull/13698 is released
-            ForceStop-ElasticAgent
 
             { Uninstall-MSI -Path $PathToLatestMSI -LogToDir $MSIUninstallParameters.LogToDir -Flags 'INSTALLARGS="--invalid-flag"' } | Should -Throw
 

--- a/src/agent-qa/msi.tests.ps1
+++ b/src/agent-qa/msi.tests.ps1
@@ -149,9 +149,7 @@ Describe 'Elastic Agent MSI Installer' {
 
             { Install-MSI -Path $PathToLatestMSI @MSIInstallParameters } | Should -Throw -ExpectedMessage '*service Elastic Agent already exists*'
 
-            if ((Get-Service "Elastic Agent" -Erroraction SilentlyContinue).DisplayName -eq "Fake Service") {
-                Remove-Service "Elastic Agent"
-            }
+            Get-Service "Elastic Agent" -ErrorAction SilentlyContinue | Should -BeNullOrEmpty -Because "the agent's rollback on install failure should have removed the 'Elastic Agent' service"
 
             # QUIRK: The MSI install cache is left behind when installation fails and must be removed manually
             Clean-ElasticAgentDirectory

--- a/src/installer/BeatPackageCompiler/AgentCustomAction.cs
+++ b/src/installer/BeatPackageCompiler/AgentCustomAction.cs
@@ -40,10 +40,6 @@ namespace Elastic.PackageCompiler.Beats
                 {
                     // The agent binary is left behind when installation fails and must be removed manually
                     RemoveFile(session, @"C:\Program Files\Elastic\Agent\elastic-agent.exe");
-
-                    // The agent's managed uninstall key is left behind when installation fails and must be removed manually
-                    // TODO(samuevl): remove when https://github.com/elastic/elastic-agent/pull/13705 is released
-                    RemoveManagedUninstallKey(session);
                 }
 
                 return process.ExitCode == 0 ? ActionResult.Success : ActionResult.Failure;

--- a/src/installer/BeatPackageCompiler/AgentCustomAction.cs
+++ b/src/installer/BeatPackageCompiler/AgentCustomAction.cs
@@ -105,20 +105,6 @@ namespace Elastic.PackageCompiler.Beats
             }
         }
 
-        private static void RemoveManagedUninstallKey(Session session)
-        {
-            try
-            {
-                const string keyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Elastic Agent";
-                Registry.LocalMachine.DeleteSubKeyTree(keyPath, false);
-                session.Log("Removed agent-managed uninstall registry key: HKLM\\" + keyPath);
-            }
-            catch (Exception ex)
-            {
-                session.Log("Failed to remove agent-managed uninstall registry key: " + ex.ToString());
-            }
-        }
-
         [CustomAction]
         public static ActionResult UpgradeAction(Session session)
         {


### PR DESCRIPTION
The upstream agent fixes have shipped:

- https://github.com/elastic/elastic-agent/pull/13698
- https://github.com/elastic/elastic-agent/pull/13705
- https://github.com/elastic/elastic-agent/pull/13878

The MSI installer no longer needs to manually remove the agent's managed uninstall key on install failure and the test suite no longer needs to force-stop the agent before uninstall. 